### PR TITLE
Sort of implemented arbitrary aspect ratio and mouse movement improvements

### DIFF
--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -996,7 +996,11 @@ static float gfx_adjust_x_for_aspect_ratio(float x) {
     if (fbActive) {
         return x;
     } else {
+#ifdef PLATFORM_N64
         return x * (4.0f / 3.0f) / ((float)gfx_current_dimensions.width / (float)gfx_current_dimensions.height);
+#else
+        return x * ((float)gfx_current_window_dimensions.width / gfx_current_window_dimensions.height) / ((float)gfx_current_dimensions.width / (float)gfx_current_dimensions.height);
+#endif
     }
 }
 
@@ -2582,9 +2586,13 @@ extern "C" void gfx_start_frame(void) {
         gfx_current_window_dimensions.height = 1;
     }
 
+#ifdef PLATFORM_N64
+    gfx_current_dimensions.aspect_ratio = 4.0f / 3.0f;
+#else
     // for now ensure that the game renders in a centered 4:3 window
     // proper 16:9 support requires some fixes, namely the sky, fullscreen fades and room culling
-    gfx_current_dimensions.aspect_ratio = 4.0f / 3.0f;
+    gfx_current_dimensions.aspect_ratio = (float)gfx_current_window_dimensions.width / gfx_current_window_dimensions.height;
+#endif
     gfx_current_dimensions.height = gfx_current_window_dimensions.height;
     gfx_current_dimensions.width = gfx_current_dimensions.height * gfx_current_dimensions.aspect_ratio;
     gfx_current_game_window_viewport.width = gfx_current_dimensions.width;

--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -10897,11 +10897,15 @@ void bgunRender(Gfx **gdlptr)
 	if (g_Vars.currentplayer->teleportstate != TELEPORTSTATE_INACTIVE) {
 		f32 f2;
 
+#ifdef PLATFORM_N64
 		if (optionsGetScreenRatio() == SCREENRATIO_16_9) {
 			f2 = player0f0bd358() * 1.3333334f;
 		} else {
 			f2 = player0f0bd358();
 		}
+#else
+		f2 = player0f0bd358();
+#endif
 
 		gdl = vi0000b0e8(gdl, 60, f2);
 	}

--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -1827,6 +1827,7 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 				bgunSwivelWithDamp(x, y, g_Vars.currentplayer->autoaimdamp);
 			}
 		} else {
+#ifdef PLATFORM_N64
 			// This code moves the crosshair as the player turns and makes
 			// it return to the centre when not affected by anything else.
 			if (g_Vars.currentplayer->autoaimdamp < (PAL ? 0.974f : 0.979f)) {
@@ -1841,6 +1842,10 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 			y = -g_Vars.currentplayer->speedverta * 0.1f + g_Vars.currentplayer->gunextraaimy;
 
 			bgunSwivelWithDamp(x, y, PAL ? 0.955f : 0.963f);
+#else
+			bgunSetAimType(0);
+			bgunSwivelWithoutDamp((movedata.c1stickxraw * 0.65f) / 80.0f, (movedata.c1stickyraw * 0.65f) / 80.0f);
+#endif
 		}
 	} else if (movedata.canmanualaim) {
 		// Adjust crosshair's position on screen

--- a/src/game/player.c
+++ b/src/game/player.c
@@ -1,4 +1,7 @@
 #include <ultra64.h>
+#ifndef PLATFORM_N64
+#include "../fast3d/gfx_api.h"
+#endif
 #include "constants.h"
 #include "game/bondeyespy.h"
 #include "game/bondmove.h"
@@ -2996,7 +2999,11 @@ f32 player0f0bd358(void)
 	result = (f32)width / (f32)height;
 	result = g_ViModes[g_ViRes].yscale * result;
 
+#ifdef PLATFORM_N64
 	return result;
+#else
+	return result * (((float)gfx_current_window_dimensions.width / gfx_current_window_dimensions.height) / (4.0f / 3.0f));
+#endif
 }
 
 void playerUpdateShake(void)
@@ -3152,11 +3159,15 @@ void playerTick(bool arg0)
 	var800800f0jf = 0;
 #endif
 
+#ifdef PLATFORM_N64
 	if (optionsGetScreenRatio() == SCREENRATIO_16_9) {
 		aspectratio = player0f0bd358() * 1.33333333f;
 	} else {
 		aspectratio = player0f0bd358();
 	}
+#else
+	aspectratio = player0f0bd358();
+#endif
 
 #if PAL
 	aspectratio *= 1.1904761791229f;


### PR DESCRIPTION
I sort of implemented arbitrary aspect ratios in a bit of a hacky way. But it is based on the aspect ratio functionality the game provided in the Video settings, so it only affects the in-game camera.

This also caused the swivel movement of the gun to be increased horizontally, which made more difficult to aim. I disabled it completely, which I think it provides the most precise aiming for mouse controls (if auto aim is also disabled). It should probably be enabled again if using controller though.