### PR TITLE
Fix default control scheme for combat sim

### DIFF
--- a/src/game/mplayer/mplayer.c
+++ b/src/game/mplayer/mplayer.c
@@ -372,7 +372,7 @@ void mpPlayerSetDefaults(s32 playernum, bool autonames)
 
 	func0f187fbc(playernum);
 
-	g_PlayerConfigsArray[playernum].controlmode = CONTROLMODE_11;
+	g_PlayerConfigsArray[playernum].controlmode = CONTROLMODE_12;
 
 	g_PlayerConfigsArray[playernum].options = OPTION_LOOKAHEAD
 		| OPTION_SIGHTONSCREEN


### PR DESCRIPTION
the default control scheme for new profiles in combat simulations was being set to 1.1 instead of 1.2 this just changes the number, its very tiny