### PR TITLE
Adjust spark scale depending on output resolution

### DIFF
--- a/src/game/sparks.c
+++ b/src/game/sparks.c
@@ -425,6 +425,9 @@ Gfx *sparksRender(Gfx *gdl)
 
 					sp120 *= 0.2f;
 					sp120 *= viGetFovY() / 60.0f;
+#ifndef PLATFORM_N64 // adjust scale for port
+					sp120 *= (float)(SCREEN_WIDTH_LO * SCREEN_HEIGHT_LO) / (float)(SCREEN_WIDTH_HI * SCREEN_HEIGHT_HI);
+#endif
 
 					mtx4LoadIdentity(&spd4);
 


### PR DESCRIPTION
This adjusts the spark scale calculation to appear smaller.

[Before](https://github.com/fgsfdsfgs/perfect_dark/assets/80724828/1e84c3e8-bad1-4b40-85d9-7798ab146fa0) / [After](https://github.com/fgsfdsfgs/perfect_dark/assets/80724828/beb2803b-7429-4db5-8ebc-5c7628e2c7d2)