### PR TITLE
Always interpolate character animations

### DIFF
--- a/src/game/chr.c
+++ b/src/game/chr.c
@@ -2730,6 +2730,9 @@ s32 chrTick(struct prop *prop)
 			f32 prevfrac2;
 			s32 prevframe2a;
 
+#ifndef PLATFORM_N64 // always interpolate animation
+			anim = model->anim;
+#else
 			if (g_Vars.normmplayerisrunning) {
 				if (g_MpSetup.options & (MPOPTION_SLOWMOTION_ON | MPOPTION_SLOWMOTION_SMART)) {
 					limit = 2000 * 2000;
@@ -2775,6 +2778,7 @@ s32 chrTick(struct prop *prop)
 					}
 				}
 			}
+#endif
 
 			modelSetMatricesWithAnim(&sp210, model);
 


### PR DESCRIPTION
This PR ifdef's out the code relating to distance checking for animation interpolation, so they animate at 60 hz  regardless of their distance to the player.