### PR TITLE
Don't draw LODs for port

### DIFF
--- a/port/src/pdmain.c
+++ b/port/src/pdmain.c
@@ -59,6 +59,7 @@
 #include "lib/snd.h"
 #include "lib/memp.h"
 #include "lib/mema.h"
+#include "lib/model.h"
 #include "lib/profile.h"
 #include "lib/videbug.h"
 #include "lib/debughud.h"
@@ -263,6 +264,8 @@ void mainInit(void)
 	racesInit();
 	bodiesInit();
 	titleInit();
+
+	modelSetDistanceChecksDisabled(true); // don't use LODs
 
 	g_MainIsBooting = 0;
 }

--- a/src/include/lib/model.h
+++ b/src/include/lib/model.h
@@ -9,6 +9,7 @@ extern Vtx *(*g_ModelVtxAllocatorFunc)(s32 numvertices);
 extern void (*g_ModelJointPositionedFunc)(s32 mtxindex, Mtxf *mtx);
 
 bool modelasm00018680(struct modelrenderdata *renderdata, struct model *model);
+void modelSetDistanceChecksDisabled(bool disabled);
 void modelSetDistanceScale(f32 value);
 void modelSetVtxAllocatorFunc(Vtx *(*fn)(s32 numvertices));
 s32 modelFindNodeMtxIndex(struct modelnode *node, s32 arg1);


### PR DESCRIPTION
This PR sets g_ModelDistanceDisabled to true at mainInit(), which disables distance checking for model rendering.