### PR TITLE
Fix menu crash when issuing order to all bots

### DIFF
--- a/src/game/activemenu.c
+++ b/src/game/activemenu.c
@@ -609,6 +609,9 @@ void amChangeScreen(s32 step)
 		if (g_AmMenus[g_AmIndex].allbots) {
 			// Weapon selection, second function, and bot command menu
 
+#ifndef PLATFORM_N64 // fix for port
+			maxscreenindex = g_Vars.currentplayer->numaibuddies > 0 ? 2 : 1;
+#else
 			// @bug: This is missing a check to see if there are any bots on
 			// your team. In most cases this isn't a problem because the player
 			// opens the screen for a single bot then uses R to switch to all
@@ -618,6 +621,7 @@ void amChangeScreen(s32 step)
 			// part runs first and sets the screen index to an invalid value,
 			// causing a crash.
 			maxscreenindex = 2;
+#endif
 		} else {
 			// Weapon selection, second function and one for each AI buddy
 			maxscreenindex = g_Vars.currentplayer->numaibuddies + 1;

--- a/src/game/activemenu.c
+++ b/src/game/activemenu.c
@@ -609,9 +609,6 @@ void amChangeScreen(s32 step)
 		if (g_AmMenus[g_AmIndex].allbots) {
 			// Weapon selection, second function, and bot command menu
 
-#ifndef PLATFORM_N64 // fix for port
-			maxscreenindex = g_Vars.currentplayer->numaibuddies > 0 ? 2 : 1;
-#else
 			// @bug: This is missing a check to see if there are any bots on
 			// your team. In most cases this isn't a problem because the player
 			// opens the screen for a single bot then uses R to switch to all
@@ -621,7 +618,6 @@ void amChangeScreen(s32 step)
 			// part runs first and sets the screen index to an invalid value,
 			// causing a crash.
 			maxscreenindex = 2;
-#endif
 		} else {
 			// Weapon selection, second function and one for each AI buddy
 			maxscreenindex = g_Vars.currentplayer->numaibuddies + 1;

--- a/src/game/activemenutick.c
+++ b/src/game/activemenutick.c
@@ -77,7 +77,7 @@ void amTick(void)
 					}
 
 					if (buttonsstate & A_BUTTON) {
-#if VERSION >= VERSION_JPN_FINAL
+#if VERSION >= VERSION_JPN_FINAL || !defined(PLATFORM_N64)
 						if (g_Vars.currentplayer->numaibuddies > 0) {
 							g_AmMenus[g_AmIndex].allbots = true;
 						}
@@ -91,7 +91,7 @@ void amTick(void)
 					}
 
 					if ((buttonsstate & R_TRIG) || (buttonsstate & L_TRIG)) {
-#if VERSION >= VERSION_JPN_FINAL
+#if VERSION >= VERSION_JPN_FINAL || !defined(PLATFORM_N64)
 						if (g_Vars.currentplayer->numaibuddies > 0) {
 							g_AmMenus[g_AmIndex].allbots = true;
 						}


### PR DESCRIPTION
This PR fixes a hard crash when attempting to order all team bots in multiplayer.