### PR TITLE
Rate limit stuckage RNG for skedar doors

### DIFF
--- a/src/game/propobj.c
+++ b/src/game/propobj.c
@@ -20056,7 +20056,12 @@ bool doorCalcIntendedFrac(struct doorobj *door)
 		if (door->base.flags3 & OBJFLAG3_DOOR_STICKY) {
 			s32 value = (random() % 64) + 30;
 
+#ifndef PLATFORM_N64 // emulate low fps cal rate for stackage test
+			if (((g_Vars.lvframenum % value) == 0)
+				&& ((g_Vars.lvframe60 & 3) == 0)) {
+#else
 			if ((g_Vars.lvframenum % value) == 0) {
+#endif
 				bool dothething = false;
 				struct doorobj *loopdoor;
 


### PR DESCRIPTION
As the port now runs at 60 frames per second, the stuck logic for the skedar ruined doors will trigger more than it would have on original hardware. This PR adjusts the stuckage RNG rate for the skedar doors, so it will only execute 15 times per second.