### PR TITLE
Fix spamming footsteps for slow mode

### DIFF
--- a/src/game/footstep.c
+++ b/src/game/footstep.c
@@ -2,6 +2,7 @@
 #include "constants.h"
 #include "game/debug.h"
 #include "game/game_006900.h"
+#include "game/lv.h"
 #include "game/propsnd.h"
 #include "game/bg.h"
 #include "bss.h"
@@ -176,6 +177,16 @@ void footstepCheckDefault(struct chrdata *chr)
 							chr->footstep = 2;
 						}
 					} else {
+#ifndef PLATFORM_N64 // fix spamming footsteps for 60fps port
+						if (lvGetSlowMotionType() != SLOWMOTION_OFF && g_Vars.speedpillon == false) {
+							s32 roundedframe = (s32)(frame*2);
+							if (roundedframe == (g_FootstepAnims[i].frame1*2) && prevframe < g_FootstepAnims[i].frame1) {
+								chr->footstep = 1;
+							} else if (roundedframe == (g_FootstepAnims[i].frame2*2) && prevframe < g_FootstepAnims[i].frame2) {
+								chr->footstep = 2;
+							}
+						} else
+#endif
 						if (frame >= g_FootstepAnims[i].frame1 && prevframe < g_FootstepAnims[i].frame1) {
 							chr->footstep = 1;
 						} else if (frame >= g_FootstepAnims[i].frame2 && prevframe < g_FootstepAnims[i].frame2) {

--- a/src/game/footstep.c
+++ b/src/game/footstep.c
@@ -178,7 +178,7 @@ void footstepCheckDefault(struct chrdata *chr)
 						}
 					} else {
 #ifndef PLATFORM_N64 // fix spamming footsteps for 60fps port
-						if ((lvGetSlowMotionType() != SLOWMOTION_OFF && g_Vars.speedpillon == false) || (lvGetSlowMotionType() == SLOWMOTION_OFF && g_Vars.speedpillon == true)) {
+						if (g_Vars.lvupdate240 == LV_SLOMO_TICK_CAP) {
 							s32 roundedframe = (s32)(frame*2);
 							if (roundedframe == (g_FootstepAnims[i].frame1*2) && prevframe < g_FootstepAnims[i].frame1) {
 								chr->footstep = 1;

--- a/src/game/footstep.c
+++ b/src/game/footstep.c
@@ -178,7 +178,7 @@ void footstepCheckDefault(struct chrdata *chr)
 						}
 					} else {
 #ifndef PLATFORM_N64 // fix spamming footsteps for 60fps port
-						if (lvGetSlowMotionType() != SLOWMOTION_OFF && g_Vars.speedpillon == false) {
+						if ((lvGetSlowMotionType() != SLOWMOTION_OFF && g_Vars.speedpillon == false) || (lvGetSlowMotionType() == SLOWMOTION_OFF && g_Vars.speedpillon == true)) {
 							s32 roundedframe = (s32)(frame*2);
 							if (roundedframe == (g_FootstepAnims[i].frame1*2) && prevframe < g_FootstepAnims[i].frame1) {
 								chr->footstep = 1;

--- a/src/game/lv.c
+++ b/src/game/lv.c
@@ -97,14 +97,6 @@
 #include "lib/vi.h"
 #include "types.h"
 
-#ifdef PLATFORM_N64
-// game runs at ~30, so slomo = 1/2 of 30fps
-#define LV_SLOMO_TICK_CAP TICKS(4)
-#else
-// game runs at 60+, so slomo = 1/2 of 60fps
-#define LV_SLOMO_TICK_CAP TICKS(2)
-#endif
-
 struct sndstate *g_MiscSfxAudioHandles[3];
 u32 var800aa5bc;
 s32 g_MiscSfxActiveTypes[3];

--- a/src/include/game/lv.h
+++ b/src/include/game/lv.h
@@ -4,6 +4,14 @@
 #include "data.h"
 #include "types.h"
 
+#ifdef PLATFORM_N64
+// game runs at ~30, so slomo = 1/2 of 30fps
+#define LV_SLOMO_TICK_CAP TICKS(4)
+#else
+// game runs at 60+, so slomo = 1/2 of 60fps
+#define LV_SLOMO_TICK_CAP TICKS(2)
+#endif
+
 u32 getVar80084040(void);
 void lvInit(void);
 void lvResetMiscSfx(void);


### PR DESCRIPTION
This PR fixes an issue with last footsteps tick compare during slow motion. By doubling the current frame counter and doing an equals compare, this will ensure footsteps are triggered once.