### PR TITLE
Limit eyespy range to 75 degrees

### DIFF
--- a/src/game/bondeyespy.c
+++ b/src/game/bondeyespy.c
@@ -937,6 +937,19 @@ void eyespyProcessInput(bool allowbuttons)
 		g_Vars.currentplayer->eyespy->verta -= pitchspeed * 0.0625f * g_Vars.lvupdate60freal;
 
 		if (prevverta != g_Vars.currentplayer->eyespy->verta) {
+#ifndef PLATFORM_N64 // limit eyespy range to 75 degrees
+			while (g_Vars.currentplayer->eyespy->verta > 90.0f) {
+				g_Vars.currentplayer->eyespy->verta -= 360.0f;
+			}
+
+			if (g_Vars.currentplayer->eyespy->verta < -75.0f) {
+				g_Vars.currentplayer->eyespy->verta = -75.0f;
+			}
+
+			if (g_Vars.currentplayer->eyespy->verta > 75.0f) {
+				g_Vars.currentplayer->eyespy->verta = 75.0f;
+			}
+#endif
 			while (g_Vars.currentplayer->eyespy->verta < 0.0f) {
 				g_Vars.currentplayer->eyespy->verta += 360.0f;
 			}


### PR DESCRIPTION
This PR introduces some clamping calculations for the eyespy device. It will now clamp to a 75 degree cone instead of letting the player invert back onto itself. This is almost needed due to the lack of lookahead.