### PR TITLE
Adjust FOV zoom speed when using non-default FOV

### DIFF
--- a/src/game/player.c
+++ b/src/game/player.c
@@ -2063,11 +2063,19 @@ f32 playerGetZoomFovY(void)
 
 void playerTweenFovY(f32 targetfovy)
 {
+	f32 speed = 15.0f / 30.0f;
+
+#ifndef PLATFORM_N64
+	if (videoGetPlayerFovY() > 60.0f) { // adjust zoom speed depending on non-default fov setting (higher fov == faster zoom)
+		speed /= videoGetPlayerFovY() / 60.0f;
+	}
+#endif
+
 	if (playerGetZoomFovY() != targetfovy) {
 		if (g_Vars.currentplayer->zoominfovy > targetfovy) {
-			playerSetZoomFovY(targetfovy, (g_Vars.currentplayer->zoominfovy - targetfovy) * 15.0f / 30.0f);
+			playerSetZoomFovY(targetfovy, (g_Vars.currentplayer->zoominfovy - targetfovy) * speed);
 		} else {
-			playerSetZoomFovY(targetfovy, (targetfovy - g_Vars.currentplayer->zoominfovy) * 15.0f / 30.0f);
+			playerSetZoomFovY(targetfovy, (targetfovy - g_Vars.currentplayer->zoominfovy) * speed);
 		}
 	}
 }


### PR DESCRIPTION
This PR matches the same behavior present in 1964GEPD, where using a non-default FOV above 60 will adjust the zoom in/out speed.