### PR TITLE
Config option to control crosshair/gun sway

### DIFF
--- a/port/src/input.c
+++ b/port/src/input.c
@@ -130,6 +130,8 @@ static const char *vkJoyNames[] = {
 
 static char vkNames[VK_TOTAL_COUNT][64];
 
+f32 crosshairSway = 1.f;
+
 void inputSetDefaultKeyBinds(void)
 {
 	// TODO: make VK constants for all these
@@ -458,6 +460,8 @@ s32 inputInit(void)
 	}
 
 	inputLoadBinds();
+
+	crosshairSway = configGetFloat("Input.CrosshairSway", 1.f);
 
 	return connectedMask;
 }

--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -1999,8 +1999,8 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 				xscale = 1.f;
 				yscale = 1.f;
 			}
-			x = g_Vars.currentplayer->speedtheta * 0.3f * xscale + g_Vars.currentplayer->gunextraaimx;
-			y = -g_Vars.currentplayer->speedverta * 0.1f * yscale + g_Vars.currentplayer->gunextraaimy;
+			x = g_Vars.currentplayer->speedtheta * 0.3f * crosshairSway * xscale + g_Vars.currentplayer->gunextraaimx;
+			y = -g_Vars.currentplayer->speedverta * 0.1f * crosshairSway * yscale + g_Vars.currentplayer->gunextraaimy;
 #endif
 
 			bgunSwivelWithDamp(x, y, PAL ? 0.955f : 0.963f);

--- a/src/include/game/bondmove.h
+++ b/src/include/game/bondmove.h
@@ -4,6 +4,10 @@
 #include "data.h"
 #include "types.h"
 
+#ifndef PLATFORM_N64
+extern f32 crosshairSway;
+#endif
+
 void bmoveSetControlDef(u32 controldef);
 void bmoveSetAutoMoveCentreEnabled(bool enabled);
 void bmoveSetAutoAimY(bool enabled);


### PR DESCRIPTION
PR adds a CrosshairSway option to control crosshair/gun sway (100% by default). A bit of a cheat, but makes mouse aim feel better on PC for those that want it