### PR TITLE
Allow classic weapons to be used in multiplayer

### DIFF
--- a/src/game/botinv.c
+++ b/src/game/botinv.c
@@ -70,6 +70,16 @@ struct aibotweaponpreference g_AibotWeaponPreferences[] = {
 	/*0x21*/ { 40,  176, 0,   0,   0, 0, BOTDISTCFG_THROWEXPLOSIVE, BOTDISTCFG_DEFAULT,        5,             5,   1,  1,  1, 0 }, // WEAPON_PROXIMITYMINE
 	/*0x22*/ { 44,  156, 0,   0,   1, 0, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        5,             5,   2,  2,  1, 0 }, // WEAPON_REMOTEMINE
 	/*0x23*/ { 8,   8,   0,   0,   0, 0, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        0,             0,   0,  0,  1, 0 }, // WEAPON_COMBATBOOST
+#ifndef PLATFORM_N64 // add all classic weapons to multiplayer
+	/*0x24*/ { 56,  60,  84,  88,  1, 1, BOTDISTCFG_PISTOL,         BOTDISTCFG_CLOSE,          30,            0,   10, 0,  1, 0 }, // WEAPON_PP9I
+	/*0x25*/ { 56,  60,  84,  88,  1, 1, BOTDISTCFG_PISTOL,         BOTDISTCFG_CLOSE,          30,            0,   10, 0,  1, 0 }, // WEAPON_CC13
+	/*0x26*/ { 56,  60,  84,  88,  1, 1, BOTDISTCFG_DEFAULT,        BOTDISTCFG_CLOSE,          30,            0,   10, 0,  1, 0 }, // WEAPON_KL01313
+	/*0x27*/ { 124, 148, 0,   0,   1, 1, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        90,            0,   30, 0,  1, 0 }, // WEAPON_KF7SPECIAL
+	/*0x28*/ { 116, 128, 136, 152, 1, 1, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        100,           0,   30, 0,  1, 0 }, // WEAPON_ZZT
+	/*0x29*/ { 124, 148, 0,   0,   1, 1, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        90,            0,   30, 0,  1, 0 }, // WEAPON_DMC
+	/*0x2a*/ { 156, 180, 0,   0,   1, 0, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        150,           0,   30, 0,  1, 0 }, // WEAPON_AR53
+	/*0x2b*/ { 164, 188, 0,   0,   1, 1, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        200,           0,   40, 0,  1, 0 }, // WEAPON_RCP45
+#else
 	/*0x24*/ { 0,   0,   0,   0,   0, 0, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        0,             0,   0,  0,  1, 0 }, // WEAPON_PP9I
 	/*0x25*/ { 0,   0,   0,   0,   0, 0, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        0,             0,   0,  0,  1, 0 }, // WEAPON_CC13
 	/*0x26*/ { 0,   0,   0,   0,   0, 0, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        0,             0,   0,  0,  1, 0 }, // WEAPON_KL01313
@@ -78,6 +88,7 @@ struct aibotweaponpreference g_AibotWeaponPreferences[] = {
 	/*0x29*/ { 0,   0,   0,   0,   0, 0, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        0,             0,   0,  0,  1, 0 }, // WEAPON_DMC
 	/*0x2a*/ { 0,   0,   0,   0,   0, 0, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        0,             0,   0,  0,  1, 0 }, // WEAPON_AR53
 	/*0x2b*/ { 0,   0,   0,   0,   0, 0, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        0,             0,   0,  0,  1, 0 }, // WEAPON_RCP45
+#endif
 	/*0x2c*/ { 0,   0,   0,   0,   0, 0, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        0,             0,   0,  0,  1, 0 }, // WEAPON_PSYCHOSISGUN
 	/*0x2d*/ { 0,   0,   0,   0,   0, 0, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        0,             0,   0,  0,  1, 0 }, // WEAPON_NIGHTVISION
 	/*0x2e*/ { 0,   0,   0,   0,   0, 0, BOTDISTCFG_DEFAULT,        BOTDISTCFG_DEFAULT,        0,             0,   0,  0,  1, 0 }, // WEAPON_EYESPY

--- a/src/game/mplayer/mplayer.c
+++ b/src/game/mplayer/mplayer.c
@@ -97,6 +97,16 @@ struct mpweapon g_MpWeapons[NUM_MPWEAPONS] = {
 	/*0x24*/ { WEAPON_COMBATBOOST,      0,                    0,   0,                   0,  1, MPFEATURE_WEAPON_COMBATBOOST,     MODEL_CHRSPEEDPILL,     256 },
 	/*0x25*/ { WEAPON_MPSHIELD,         0,                    0,   0,                   0,  1, MPFEATURE_WEAPON_SHIELD,          MODEL_CHRSHIELD,        256 },
 	/*0x26*/ { WEAPON_DISABLED },
+#ifndef PLATFORM_N64 // add all classic weapons to multiplayer
+	/*0x27*/ { WEAPON_PP9I,             AMMOTYPE_PISTOL,      80,  0,                   0,  1, 0,                                MODEL_CHRWPPK,          256 },
+	/*0x28*/ { WEAPON_CC13,             AMMOTYPE_PISTOL,      80,  0,                   0,  1, 0,                                MODEL_CHRTT33,          256 },
+	/*0x29*/ { WEAPON_KL01313,          AMMOTYPE_SMG,         100, 0,                   0,  1, 0,                                MODEL_CHRSKORPION,      256 },
+	/*0x2a*/ { WEAPON_KF7SPECIAL,       AMMOTYPE_RIFLE,       100, 0,                   0,  1, 0,                                MODEL_CHRKALASH,        256 },
+	/*0x2b*/ { WEAPON_ZZT,              AMMOTYPE_SMG,         100, 0,                   0,  1, 0,                                MODEL_CHRUZI,           256 },
+	/*0x2c*/ { WEAPON_DMC,              AMMOTYPE_SMG,         100, 0,                   0,  1, 0,                                MODEL_CHRMP5K,          256 },
+	/*0x2d*/ { WEAPON_AR53,             AMMOTYPE_RIFLE,       100, 0,                   0,  1, 0,                                MODEL_CHRM16,           256 },
+	/*0x2e*/ { WEAPON_RCP45,            AMMOTYPE_SMG,         150, 0,                   0,  1, 0,                                MODEL_CHRFNP90,         256 },
+#endif
 };
 
 /**

--- a/src/game/playerreset.c
+++ b/src/game/playerreset.c
@@ -330,7 +330,11 @@ void playerReset(void)
 
 	if (cheatIsActive(CHEAT_CC13)) {
 		invGiveSingleWeapon(WEAPON_CC13);
+#ifndef PLATFORM_N64 // give the correct ammo for port
+		bgunSetAmmoQuantity(AMMOTYPE_PISTOL, 200);
+#else
 		bgunSetAmmoQuantity(AMMOTYPE_RIFLE, 200);
+#endif
 	}
 
 	if (cheatIsActive(CHEAT_KL01313)) {

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -2950,7 +2950,19 @@
 #define MPWEAPON_COMBATBOOST      (VERSION == VERSION_JPN_FINAL ? 0x23 : 0x24)
 #define MPWEAPON_SHIELD           (VERSION == VERSION_JPN_FINAL ? 0x24 : 0x25)
 #define MPWEAPON_DISABLED         (VERSION == VERSION_JPN_FINAL ? 0x25 : 0x26)
+#ifdef PLATFORM_N64
 #define NUM_MPWEAPONS             (VERSION == VERSION_JPN_FINAL ? 0x26 : 0x27)
+#else // add all classic weapons to multiplayer
+#define MPWEAPON_PP9I             (VERSION == VERSION_JPN_FINAL ? 0x26 : 0x27)
+#define MPWEAPON_CC13             (VERSION == VERSION_JPN_FINAL ? 0x27 : 0x28)
+#define MPWEAPON_KL01313          (VERSION == VERSION_JPN_FINAL ? 0x28 : 0x29)
+#define MPWEAPON_KF7SPECIAL       (VERSION == VERSION_JPN_FINAL ? 0x29 : 0x2a)
+#define MPWEAPON_ZZT              (VERSION == VERSION_JPN_FINAL ? 0x2a : 0x2b)
+#define MPWEAPON_DMC              (VERSION == VERSION_JPN_FINAL ? 0x2b : 0x2c)
+#define MPWEAPON_AR53             (VERSION == VERSION_JPN_FINAL ? 0x2c : 0x2d)
+#define MPWEAPON_RCP45            (VERSION == VERSION_JPN_FINAL ? 0x2d : 0x2e)
+#define NUM_MPWEAPONS             (VERSION == VERSION_JPN_FINAL ? 0x2e : 0x2f)
+#endif
 
 #define MUSICEVENTTYPE_PLAY        1
 #define MUSICEVENTTYPE_STOP        2


### PR DESCRIPTION
_As this is a gameplay enhancement, I am not too sure if this PR will be accepted._

This PR adds the classic weapons in the multiplayer menu, and implements some basic defaults for bots to use them appropriately.