### PR TITLE
Fix choppy audio at sub-60fps framerates

### DIFF
--- a/port/src/pdsched.c
+++ b/port/src/pdsched.c
@@ -235,9 +235,13 @@ void schedStartFrame(OSSched *sc)
 
 void schedAudioFrame(OSSched *sc)
 {
+	s32 i;
+
 	if (!g_SndDisabled) {
-		amgrFrame();
-		audioEndFrame();
+		for (i = 0; i < g_Vars.diffframe60; i++) {
+			amgrFrame();
+			audioEndFrame();
+		}
 	}
 }
 


### PR DESCRIPTION
This ticks the audio thread multiple times according to the value in `g_Vars.diffframe60`.

As a result, this game can now be pleasantly played at 50 FPS which seems to be low enough to make the infinite-firing guards bug not appear.