### PR TITLE
Fix buffer overflow in creditsResetSlides

### DIFF
--- a/src/game/credits.c
+++ b/src/game/credits.c
@@ -1079,7 +1079,7 @@ void creditsResetSlides(void)
 
 		g_CreditsData->coreteammap[i + 1] = pool[index];
 
-		while (index < NUM_CORE_TEAM - i) {
+		while (index < NUM_CORE_TEAM - i - 1) {
 			pool[index] = pool[index + 1];
 			index++;
 		}


### PR DESCRIPTION
While moving the elements from the `pool` towards the start of the array, the program might crash because when `ì` is zero, it will fetch an element after the end of the array. 

To ensure an off by one error doesn't occur, `- 1` must be added when performing the loop.

I thought the correct fix would be to increase the size of the `pool` array to have the same size as `coreteammap`, which is 17 (calculated as `NUM_CORE_TEAM + 1`), but `coreteammap` never uses its first element and when this function assigns to it, it does `+ 1` which warrants it being an element bigger. 

From my examinations, this fix is what the developers intended to do. 

This crash was detected by using an address sanitizer. It can be reproduced by compiling the game code with `-fsanitize=address  -fno-omit-frame-pointer` and starting the game without generating inputs so that it plays the credit sequence background after the intro. 