### PR TITLE
port: add a config option to disable texture filtering on fonts

### DIFF
--- a/port/include/video.h
+++ b/port/include/video.h
@@ -19,6 +19,7 @@ s32 videoGetNativeHeight(void);
 s32 videoGetWidth(void);
 s32 videoGetHeight(void);
 f32 videoGetAspect(void);
+u32 videoGetFontTextureFilter(void);
 
 s32 videoCreateFramebuffer(u32 w, u32 h);
 void videoSetFramebuffer(s32 target);

--- a/port/src/video.c
+++ b/port/src/video.c
@@ -20,6 +20,7 @@ static u32 dlcount = 0;
 static u32 frames = 0;
 static u32 framesPerSec = 0;
 static f64 startTime, endTime, fpsTime;
+static u32 fontTextureFilter = 1;
 
 s32 videoInit(void)
 {
@@ -45,6 +46,8 @@ s32 videoInit(void)
 	u32 filter = configGetInt("Video.TextureFilter", FILTER_LINEAR);
 	if (filter > FILTER_THREE_POINT) filter = FILTER_THREE_POINT;
 	renderingAPI->set_texture_filter((enum FilteringMode)filter);
+
+	fontTextureFilter = configGetInt("Video.FontTextureFilter", 1);
 
 	initDone = true;
 	return 0;
@@ -132,6 +135,11 @@ s32 videoGetHeight(void)
 f32 videoGetAspect(void)
 {
 	return gfx_current_dimensions.aspect_ratio;
+}
+
+u32 videoGetFontTextureFilter(void)
+{
+	return fontTextureFilter;
 }
 
 s32 videoCreateFramebuffer(u32 w, u32 h)

--- a/src/game/game_1531a0.c
+++ b/src/game/game_1531a0.c
@@ -394,7 +394,12 @@ Gfx *text0f153628(Gfx *gdl)
 	}
 #endif
 	else {
-		gDPSetTextureFilter(gdl++, G_TF_BILERP);
+		if (videoGetFontTextureFilter() == 0) {
+			gDPSetTextureFilter(gdl++, G_TF_POINT);
+		}
+		else {
+			gDPSetTextureFilter(gdl++, G_TF_BILERP);
+		}
 	}
 
 	return gdl;


### PR DESCRIPTION
Fixes  #118.
Seems like it works without any hassle, haven't seen any side effects. The sideways text on the menu has an entire pixel cutoff but that seems to be a separate issue regardless of filtering.