### PR TITLE
double reload fix and per-hand reload impulses

### DIFF
--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -6035,8 +6035,8 @@ s32 bgunConsiderReloadTap() {
 	s32 righthandfun = righthand.activatesecondary;
 	s32 lefthandfun = lefthand.activatesecondary;
 
-	righttap = (righthand.loadedammo[righthandfun] > 0) ? JO_ACTION_RELOAD_RIGHT: 0;
-	lefttap = (lefthand.loadedammo[lefthandfun] > 0)    ? JO_ACTION_RELOAD_LEFT : 0;
+	righttap = (righthand.loadedammo[righthandfun] > 0 && righthand.loadedammo[righthandfun] < righthand.clipsizes[righthandfun]) ? JO_ACTION_RELOAD_RIGHT: 0;
+	lefttap = (lefthand.loadedammo[lefthandfun] > 0 && lefthand.loadedammo[lefthandfun] < lefthand.clipsizes[lefthandfun])    ? JO_ACTION_RELOAD_LEFT : 0;
 
 	return righttap | lefttap;
 }

--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -6008,6 +6008,39 @@ char *bgunGetShortName(s32 weaponnum)
 
 const char var7f1ac170[] = "wantedfn %d tiggle %d\n";
 
+s32 bgunConsiderReloadTap() {
+	// there is a timing issue in pd
+	// where if you press reload immediately after reloading triggers
+	// followed by shooting where the hand of the player
+	// will trigger an unwanted reload
+	//
+	// so we'll need to check each hand for eligibility of the reload request
+	// and drop it if appropriate
+	//
+	// we'll returned the JO_ACTION_RELOAD_* constants OR'ed together
+	// This will make it easier to implement per-hand reloading buttons
+	// and gates the reload impulse behind the ammo check.
+
+	s8 i;
+	s8 righttap = 0;
+	s8 lefttap = 0;
+
+	s32 righthandwpn = bgunGetWeaponNum(HAND_RIGHT);
+	s32 lefthandwpn = bgunGetWeaponNum(HAND_LEFT);
+
+
+	struct player *player = g_Vars.currentplayer;
+	struct hand righthand = player->hands[HAND_RIGHT];
+	struct hand lefthand = player->hands[HAND_LEFT];
+	s32 righthandfun = righthand.activatesecondary;
+	s32 lefthandfun = lefthand.activatesecondary;
+
+	righttap = (righthand.loadedammo[righthandfun] > 0) ? JO_ACTION_RELOAD_RIGHT: 0;
+	lefttap = (lefthand.loadedammo[lefthandfun] > 0)    ? JO_ACTION_RELOAD_LEFT : 0;
+
+	return righttap | lefttap;
+}
+
 void bgunReloadIfPossible(s32 handnum)
 {
 	struct player *player = g_Vars.currentplayer;

--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -1461,7 +1461,7 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 						// Handle ALT1 / MI Reload Hack
 						for (i = 0; i < numsamples; i++) {
 							if (joyGetButtonsOnSample(i, contpad1, c1allowedbuttons & BUTTON_RELOAD)) {
-								movedata.alt1tapcount++;
+								movedata.alt1tapcount = bgunConsiderReloadTap();
 							}
 						}
 
@@ -1644,7 +1644,7 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 	g_Vars.currentplayer->bondactivateorreload = 0;
 
 	if (movedata.alt1tapcount) {
-		g_Vars.currentplayer->bondactivateorreload = g_Vars.currentplayer->bondactivateorreload | JO_ACTION_RELOAD;
+		g_Vars.currentplayer->bondactivateorreload = g_Vars.currentplayer->bondactivateorreload | movedata.alt1tapcount;
 	}
 	if (movedata.btapcount) {
 		g_Vars.currentplayer->activatetimelast = g_Vars.currentplayer->activatetimethis;

--- a/src/game/lv.c
+++ b/src/game/lv.c
@@ -1290,15 +1290,18 @@ Gfx *lvRender(Gfx *gdl)
 				}
 
 				// Handle opening doors and reloading
-				if (g_Vars.currentplayer->bondactivateorreload & JO_ACTION_RELOAD) {
-					if (g_Vars.currentplayer->hands[HAND_RIGHT].state != HANDSTATE_RELOAD){
+				if (g_Vars.currentplayer->bondactivateorreload & JO_ACTION_RELOAD_RIGHT) {
+					if (g_Vars.currentplayer->hands[HAND_RIGHT].modenext != HANDSTATE_RELOAD && g_Vars.currentplayer->hands[HAND_RIGHT].state != HANDSTATE_RELOAD){
 						bgunReloadIfPossible(HAND_RIGHT);
 
 					}
-					if (g_Vars.currentplayer->hands[HAND_LEFT].state != HANDSTATE_RELOAD) {
+					g_Vars.currentplayer->bondactivateorreload = (g_Vars.currentplayer->bondactivateorreload & ~JO_ACTION_RELOAD_RIGHT) | (g_Vars.currentplayer->bondactivateorreload & 0x0);
+				}
+				if (g_Vars.currentplayer->bondactivateorreload & JO_ACTION_RELOAD_LEFT) {
+					if (g_Vars.currentplayer->hands[HAND_LEFT].modenext != HANDSTATE_RELOAD && g_Vars.currentplayer->hands[HAND_LEFT].state != HANDSTATE_RELOAD) {
 						bgunReloadIfPossible(HAND_LEFT);
 					}
-					g_Vars.currentplayer->bondactivateorreload = (g_Vars.currentplayer->bondactivateorreload & ~JO_ACTION_RELOAD) | (g_Vars.currentplayer->bondactivateorreload & 0x0);
+					g_Vars.currentplayer->bondactivateorreload = (g_Vars.currentplayer->bondactivateorreload & ~JO_ACTION_RELOAD_LEFT) | (g_Vars.currentplayer->bondactivateorreload & 0x0);
 				}
 				if (g_Vars.currentplayer->bondactivateorreload & JO_ACTION_ACTIVATE) {
 					currentPlayerInteract(false);

--- a/src/game/lv.c
+++ b/src/game/lv.c
@@ -1289,18 +1289,26 @@ Gfx *lvRender(Gfx *gdl)
 					}
 				}
 
+				struct hand* hand;;
+				struct weaponfunc* func;
 				// Handle opening doors and reloading
 				if (g_Vars.currentplayer->bondactivateorreload & JO_ACTION_RELOAD_RIGHT) {
-					if (g_Vars.currentplayer->hands[HAND_RIGHT].modenext != HANDSTATE_RELOAD && g_Vars.currentplayer->hands[HAND_RIGHT].state != HANDSTATE_RELOAD){
+					hand = &g_Vars.currentplayer->hands[HAND_RIGHT];
+					func = weaponGetFunction(&hand->gset, hand->gset.weaponfunc);
+					// ignore the player's request to reload here if the last bullet in the clip was just fired
+					if (hand->state != HANDSTATE_RELOAD && !(hand->state == HANDSTATE_ATTACK && hand->loadedammo[func->ammoindex] == 0)) {
 						bgunReloadIfPossible(HAND_RIGHT);
-
 					}
 					g_Vars.currentplayer->bondactivateorreload = (g_Vars.currentplayer->bondactivateorreload & ~JO_ACTION_RELOAD_RIGHT) | (g_Vars.currentplayer->bondactivateorreload & 0x0);
 				}
 				if (g_Vars.currentplayer->bondactivateorreload & JO_ACTION_RELOAD_LEFT) {
-					if (g_Vars.currentplayer->hands[HAND_LEFT].modenext != HANDSTATE_RELOAD && g_Vars.currentplayer->hands[HAND_LEFT].state != HANDSTATE_RELOAD) {
+
+					hand = &g_Vars.currentplayer->hands[HAND_LEFT];
+					func = weaponGetFunction(&hand->gset, hand->gset.weaponfunc);
+					if (hand->state != HANDSTATE_RELOAD && !(hand->state == HANDSTATE_ATTACK && hand->loadedammo[func->ammoindex] == 0)) {
 						bgunReloadIfPossible(HAND_LEFT);
 					}
+
 					g_Vars.currentplayer->bondactivateorreload = (g_Vars.currentplayer->bondactivateorreload & ~JO_ACTION_RELOAD_LEFT) | (g_Vars.currentplayer->bondactivateorreload & 0x0);
 				}
 				if (g_Vars.currentplayer->bondactivateorreload & JO_ACTION_ACTIVATE) {

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -4649,7 +4649,8 @@ enum weaponnum {
 #define BODY_DARK_NEGOTIATOR  0x96
 
 #define JO_ACTION_ACTIVATE           0x0001
-#define JO_ACTION_RELOAD             0x0002
+#define JO_ACTION_RELOAD_RIGHT       0x0002
+#define JO_ACTION_RELOAD_LEFT        0x0004
 
 #ifdef PLATFORM_N64
 


### PR DESCRIPTION
Only generate the reload impulse, per-hand, if there's at least 1 round in the hand's magazine. Hand-specific reload flags would make it easier to implement per-hand reloading buttons.

Fixes #109