### PR TITLE
fix: remove height trim on rotated text

### DIFF
--- a/src/game/game_1531a0.c
+++ b/src/game/game_1531a0.c
@@ -1790,7 +1790,7 @@ Gfx *text0f15568c(Gfx *gdl, s32 *x, s32 *y, struct fontchar *curchar, struct fon
 									(*x + curchar->width) * 4 + var8007fadc,
 									G_TX_RENDERTILE,
 									var8007fae8 + 32,
-									((curchar->height - 1) << 5) + var8007fae4 + 32,
+									((curchar->height) << 5) + var8007fae4 + 32,
 									1024,
 									65536 - 1024 / var8007fad0);
 						} else {

--- a/src/game/menu.c
+++ b/src/game/menu.c
@@ -3011,7 +3011,7 @@ Gfx *dialogRender(Gfx *gdl, struct menudialog *dialog, struct menu *menu, bool l
 
 				textMeasure(&textheight, &textwidth, title, g_CharsHandelGothicXs, g_FontHandelGothicXs, 0);
 
-				x = dialogleft - 1;
+				x = dialogleft - 2;
 				y = (dialogtop + dialogbottom) / 2 - textwidth - 3;
 
 				if (y < dialogtop) {


### PR DESCRIPTION
The side text on the menu is trimmed by a single pixel, this change untrims it so the whole letters can be seen. This also shifts the left side text a pixel closer to the center menu, which will let the "I" of Inventory come in contact with the top bar of the menu. (Unsure about other languages) I'll push a change so that the left side text is shoved a pixel back to the left to counteract this. 
As far as I can see in the code the rotated text isn't used anywhere besides the menu so I don't think it'll affect anything else.

Pause Menu issue described above:
![2023 09 01 T(14 29 10)%pn_PMWh6gVVMb](https://github.com/fgsfdsfgs/perfect_dark/assets/16583255/69ca3307-7531-458a-8c7f-ef0a94b657ec)

Before:
![2023 09 01 T(13 53 31)pd_6Id05LpIvZ](https://github.com/fgsfdsfgs/perfect_dark/assets/16583255/dc9c5f10-1f2e-40a9-86e7-63ea165651a1)
After:
![2023 09 01 T(13 55 50)pd_wfjkccOJki](https://github.com/fgsfdsfgs/perfect_dark/assets/16583255/ef561ae8-1753-4923-b36b-36417fd5777f)

With texture filtering disabled from #127 
Before:
![2023 09 01 T(14 03 34)pd_DpUayIHu0q](https://github.com/fgsfdsfgs/perfect_dark/assets/16583255/922adfed-cee9-4c63-a603-b322b6fa4a36)
After:
![2023 09 01 T(13 57 18)pd_IFrklOwtqc](https://github.com/fgsfdsfgs/perfect_dark/assets/16583255/d8a922e9-f460-4dac-bfa3-0eece798c551)
