### PR TITLE
fix: return false in chrHasLosToPosWasteful if outside FOV check

### DIFF
--- a/src/game/chraction.c
+++ b/src/game/chraction.c
@@ -6579,7 +6579,11 @@ bool chrHasLosToPosWasteful(struct chrdata *chr, struct coord *pos, RoomNum *roo
 		return chrHasLosToPos(chr, pos, rooms);
 	}
 
+#ifdef N64_PLATFORM
 	return chrHasLosToPos(chr, pos, rooms);
+#else
+	return false;
+#endif
 }
 
 bool chrHasLosToProp(struct chrdata *chr, struct prop *prop)


### PR DESCRIPTION
Fixes #96 
I tested a fair bit in a few levels, mainly Chicago, Air Base, and Pelagic II. Additional testing may be needed to ensure this doesn't break anything else. Would love a second opinion on whether it feels the way it used to.