### PR TITLE
Fixed Radar logic

### DIFF
--- a/src/game/radar.c
+++ b/src/game/radar.c
@@ -156,7 +156,7 @@ Gfx *radarDrawDot(Gfx *gdl, struct prop *prop, struct coord *dist, u32 colour1, 
 			gDPFillRectangleScaled(gdl++, x - 2, y + 0, x + 1, y + 1);
 			gDPFillRectangleScaled(gdl++, x - 1, y - 1, x + 0, y + 0);
 			gdl = text0f153838(gdl);
-		} else if (g_RadarYIndicatorsEnabled && dist->y > 250) {
+		} else if (g_RadarYIndicatorsEnabled && dist->y < -250) {
 			// Up triangle
 			gdl = textSetPrimColour(gdl, (0xff >> shiftamount) + colour1);
 			gDPFillRectangleScaled(gdl++, x - 3, y - 1, x + 2, y + 2);
@@ -167,7 +167,7 @@ Gfx *radarDrawDot(Gfx *gdl, struct prop *prop, struct coord *dist, u32 colour1, 
 			gDPFillRectangleScaled(gdl++, x - 2, y + 0, x + 1, y + 1);
 			gDPFillRectangleScaled(gdl++, x - 1, y - 1, x + 0, y + 0);
 			gdl = text0f153838(gdl);
-		} else if (g_RadarYIndicatorsEnabled && dist->y < -250) {
+		} else if (g_RadarYIndicatorsEnabled && dist->y > 250) {
 			// Down triangle
 			gdl = textSetPrimColour(gdl, (0xff >> shiftamount) + colour1);
 			gDPFillRectangleScaled(gdl++, x - 3, y - 2, x + 2, y + 1);
@@ -202,7 +202,7 @@ Gfx *radarDrawDot(Gfx *gdl, struct prop *prop, struct coord *dist, u32 colour1, 
 			gDPFillRectangleScaled(gdl++, x - 2, y + 0, x + 1, y + 1);
 			gDPFillRectangleScaled(gdl++, x - 1, y - 1, x + 0, y + 0);
 			gdl = text0f153838(gdl);
-		} else if (g_RadarYIndicatorsEnabled && dist->y > 250) {
+		} else if (g_RadarYIndicatorsEnabled && dist->y < -250) {
 			// Up triangle
 			gdl = textSetPrimColour(gdl, (0xff >> shiftamount) + colour2);
 			gDPFillRectangleScaled(gdl++, x - 3, y - 1, x + 2, y + 2);
@@ -213,7 +213,7 @@ Gfx *radarDrawDot(Gfx *gdl, struct prop *prop, struct coord *dist, u32 colour1, 
 			gDPFillRectangleScaled(gdl++, x - 2, y + 0, x + 1, y + 1);
 			gDPFillRectangleScaled(gdl++, x - 1, y - 1, x + 0, y + 0);
 			gdl = text0f153838(gdl);
-		} else if (g_RadarYIndicatorsEnabled && dist->y < -250) {
+		} else if (g_RadarYIndicatorsEnabled && dist->y > 250) {
 			// Down triangle
 			gdl = textSetPrimColour(gdl, (0xff >> shiftamount) + colour2);
 			gDPFillRectangleScaled(gdl++, x - 3, y - 2, x + 2, y + 1);


### PR DESCRIPTION
In combat simulator the above / below icons on the radar minimap are inverted. This PR fixes this.