### PR TITLE
Use XBox / PC Menu A/B semantics

### DIFF
--- a/port/src/input.c
+++ b/port/src/input.c
@@ -156,7 +156,7 @@ void inputSetDefaultKeyBinds(void)
 	};
 
 	static const u32 joybinds[][2] = {
-		{ CK_B,      SDL_CONTROLLER_BUTTON_A             },
+		{ CK_A,      SDL_CONTROLLER_BUTTON_A             },
 		{ CK_X,      SDL_CONTROLLER_BUTTON_X             },
 		{ CK_Y,      SDL_CONTROLLER_BUTTON_Y             },
 		{ CK_DPAD_L, SDL_CONTROLLER_BUTTON_B,            },

--- a/src/game/menu.c
+++ b/src/game/menu.c
@@ -4624,11 +4624,11 @@ void menuProcessInput(void)
 			if (buttonsnow & BUTTON_RADIAL) {
 				inputs.select = 1;
 			}
-			// this will naturally feel nice w/ a switch layout
-			// with the default mapping for weapon-back
+
 			if (buttonsnow & BUTTON_WPNBACK) {
-				inputs.select = 1;
+				inputs.back = 1;
 			}
+
 			#endif
 			if (buttonsnow & B_BUTTON) {
 				inputs.back = 1;


### PR DESCRIPTION
I forgot to set Xbox A/B menu bindings in my earlier PR.

Fixes #110