### PR TITLE
hack: cp `inputMouseGetScaled -> inputMouseGetScaledDeltaAbsSens` for intuitive amenu UX while using aim inversion

### DIFF
--- a/port/src/input.c
+++ b/port/src/input.c
@@ -731,8 +731,8 @@ void inputMouseGetScaledDeltaAbsSens(f32 *dx, f32 *dy)
 {
 	f32 mdx, mdy;
 	if (mouseLocked) {
-		mdx = abs(mouseSensX) * (f32)mouseDX / 100.0f;
-		mdy = abs(mouseSensY) * (f32)mouseDY / 100.0f;
+		mdx = fabsf(mouseSensX) * (f32)mouseDX / 100.0f;
+		mdy = fabsf(mouseSensY) * (f32)mouseDY / 100.0f;
 	} else {
 		mdx = 0.f;
 		mdy = 0.f;

--- a/port/src/input.c
+++ b/port/src/input.c
@@ -727,6 +727,20 @@ void inputMouseGetScaledDelta(f32 *dx, f32 *dy)
 	if (dy) *dy = mdy;
 }
 
+void inputMouseGetScaledDeltaAbsSens(f32 *dx, f32 *dy)
+{
+	f32 mdx, mdy;
+	if (mouseLocked) {
+		mdx = abs(mouseSensX) * (f32)mouseDX / 100.0f;
+		mdy = abs(mouseSensY) * (f32)mouseDY / 100.0f;
+	} else {
+		mdx = 0.f;
+		mdy = 0.f;
+	}
+	if (dx) *dx = mdx;
+	if (dy) *dy = mdy;
+}
+
 const char *inputGetContKeyName(u32 ck)
 {
 	if (ck >= CK_TOTAL_COUNT) {

--- a/src/game/activemenutick.c
+++ b/src/game/activemenutick.c
@@ -70,7 +70,7 @@ void amTick(void)
 				if (j == 0 && g_Vars.currentplayernum == 0 && inputMouseIsLocked()) {
 					f32 mdx, mdy;
 					struct activemenu *am = &g_AmMenus[g_AmIndex];
-					inputMouseGetScaledDelta(&mdx, &mdy);
+					inputMouseGetScaledDeltaAbsSens(&mdx, &mdy);
 					if (mdx || mdy) {
 						am->mousex += mdx * 4.f;
 						am->mousey += mdy * 4.f;


### PR DESCRIPTION
I prefer to play shooters with Y-inverted stick controls and normal-Y mouse controls.

When the stick is inverted, I need to invert the mouse controls to achieve "normal Y movement" with the mouse. Even still, the active menu inputs with the mouse are inverted.

This is hacky but fixes this issue without adding an extra parameter/using a wrapper. 