### PR TITLE
1.2 + 1 Analog Controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,25 +34,29 @@ You must already have a Perfect Dark ROM to run the game, as specified above.
 
 ## Controls
 
-1964GEPD-style and Xbox-style bindings are partially implemented.
+1964GEPD-style and Xbox-style bindings are implemented.
 
 N64 pad buttons X and Y (or `X_BUTTON`, `Y_BUTTON` in the code) refer to the reserved buttons `0x40` and `0x80`, which are also leveraged by 1964GEPD.
 
-| Action          | Keyboard and mouse | Xbox pad | N64 pad    |
-| -               | -                  | -        | -          |
-| Fire / Accept   | LMB/Space          | RT       | Z Trigger  |
-| Aim mode        | RMB/Z              | LT       | R Trigger  |
-| Use / Cancel    | E                  | N/A      | B          |
-| Use / Accept    | N/A                | A        | A          |
-| Crouch cycle    | N/A                | L3       | D-Right    |
-| Half-Crouch     | Shift              | N/A      | D-Up       |
-| Full-Crouch     | Control            | N/A      | D-Down     |
-| Reload          | R                  | X        | X `(0x40)` |
-| Previous weapon | Mousewheel forward | B        | D-Left     |
-| Next weapon     | Mousewheel back    | Y        | Y `(0x80)` |
-| Radial menu     | Q                  | LB       | D-Down     |
-| Alt fire mode   | F                  | RB       | L Trigger  |
-| Quick-detonate  | E + Q              | A + B    | A + D-Left |
+Support for one controller, two-stick configurations are enabled for 1.2.
+
+
+| Action           | Keyboard and mouse   | Xbox pad            | N64 pad              |
+| -                | -                    | -                   | -                    |
+| Fire / Accept    | LMB/Space            | RT                  | Z Trigger            |
+| Aim mode         | RMB/Z                | LT                  | R Trigger            |
+| Use / Cancel     | E                    | N/A                 | B                    |
+| Use / Accept     | N/A                  | A                   | A                    |
+| Crouch cycle     | N/A                  | L3                  | `0x80000000` (Extra) |
+| Half-Crouch      | Shift                | N/A                 | `0x40000000` (Extra) |
+| Full-Crouch      | Control              | N/A                 | `0x20000000` (Extra) |
+| Reload           | R                    | X                   | X `(0x40)`           |
+| Previous weapon  | Mousewheel forward   | B                   | D-Left               |
+| Next weapon      | Mousewheel back      | Y                   | Y `(0x80)`           |
+| Radial menu      | Q                    | LB                  | D-Down               |
+| Alt fire mode    | F                    | RB                  | L Trigger            |
+| Alt-fire oneshot | F + LMB or E + LMB   | A + RT or RB + RT   | A + Z, L + Z         |
+| Quick-detonate   | E + Q                | A + B               | A + D-Left           |
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You must already have a Perfect Dark ROM to run the game, as specified above.
 
 1964GEPD-style and Xbox-style bindings are partially implemented.
 
-N64 pad buttons X and Y (or `X_BUTTON`, `Y_BUTTON` in the code) refer to the reserved buttons 0x40 and 0x80, which are also leveraged by 1964GEPD.
+N64 pad buttons X and Y (or `X_BUTTON`, `Y_BUTTON` in the code) refer to the reserved buttons `0x40` and `0x80`, which are also leveraged by 1964GEPD.
 
 | Action          | Keyboard and mouse | Xbox pad | N64 pad    |
 | -               | -                  | -        | -          |
@@ -44,6 +44,9 @@ N64 pad buttons X and Y (or `X_BUTTON`, `Y_BUTTON` in the code) refer to the res
 | Aim mode        | RMB/Z              | LT       | R Trigger  |
 | Use / Cancel    | E                  | N/A      | B          |
 | Use / Accept    | N/A                | A        | A          |
+| Crouch cycle    | N/A                | L3       | D-Right    |
+| Half-Crouch     | Shift              | N/A      | D-Up       |
+| Full-Crouch     | Control            | N/A      | D-Down     |
 | Reload          | R                  | X        | X `(0x40)` |
 | Previous weapon | Mousewheel forward | B        | D-Left     |
 | Next weapon     | Mousewheel back    | Y        | Y `(0x80)` |

--- a/include/PR/os_cont.h
+++ b/include/PR/os_cont.h
@@ -57,7 +57,7 @@ typedef struct {
 }OSContStatus;
 
 typedef struct {
-	u16     button;
+	u32     button;
 	s8      stick_x;		/* -80 <= stick_x <= 80 */
 	s8      stick_y;		/* -80 <= stick_y <= 80 */
 	u8	errnum;
@@ -122,23 +122,39 @@ typedef struct {
 #define CONT_EEPROM_BUSY	0x80
 
 /* Buttons */
+#define CONT_8000      0x80000000
+#define CONT_4000      0x40000000
+#define CONT_2000      0x20000000
+#define CONT_1000      0x10000000
+#define CONT_0800      0x08000000
+#define CONT_0400      0x04000000
+#define CONT_0200      0x02000000
+#define CONT_0100      0x01000000
+#define CONT_0080      0x00800000
+#define CONT_0040      0x00400000
+#define CONT_0020      0x00200000
+#define CONT_0010      0x00100000
+#define CONT_0008      0x00080000
+#define CONT_0004      0x00040000
+#define CONT_0002      0x00020000
+#define CONT_0001      0x00010000
 
-#define CONT_A      0x8000
-#define CONT_B      0x4000
-#define CONT_G	    0x2000
-#define CONT_START  0x1000
-#define CONT_UP     0x0800
-#define CONT_DOWN   0x0400
-#define CONT_LEFT   0x0200
-#define CONT_RIGHT  0x0100
-#define CONT_EXTRA1 0x0080
-#define CONT_EXTRA0 0x0040
-#define CONT_L      0x0020
-#define CONT_R      0x0010
-#define CONT_E      0x0008
-#define CONT_D      0x0004
-#define CONT_C      0x0002
-#define CONT_F      0x0001
+#define CONT_A         0x00008000
+#define CONT_B         0x00004000
+#define CONT_G	       0x00002000
+#define CONT_START     0x00001000
+#define CONT_UP        0x00000800
+#define CONT_DOWN      0x00000400
+#define CONT_LEFT      0x00000200
+#define CONT_RIGHT     0x00000100
+#define CONT_EXTRA1    0x00000080
+#define CONT_EXTRA0    0x00000040
+#define CONT_L         0x00000020
+#define CONT_R         0x00000010
+#define CONT_E         0x00000008
+#define CONT_D         0x00000004
+#define CONT_C         0x00000002
+#define CONT_F         0x00000001
 
 /* Nintendo's official button names */
 

--- a/port/include/input.h
+++ b/port/include/input.h
@@ -12,7 +12,7 @@
 #define CONT_STICK_YNEG 0x40000
 #define CONT_STICK_YPOS 0x80000
 
-#define CONT_NUM_BUTTONS 16 // not including the stick axes
+#define CONT_NUM_BUTTONS 32 // not including the stick axes
 
 enum virtkey {
   /* same order as SDL scancodes */
@@ -59,6 +59,22 @@ enum contkey {
   CK_ZTRIG,
   CK_B,
   CK_A,
+  CK_0001,
+  CK_0002,
+  CK_0004,
+  CK_0008,
+  CK_0010,
+  CK_0020,
+  CK_0040,
+  CK_0080,
+  CK_0100,
+  CK_0200,
+  CK_0400,
+  CK_0800,
+  CK_1000,
+  CK_2000,
+  CK_4000,
+  CK_8000,
   CK_STICK_XNEG,
   CK_STICK_XPOS,
   CK_STICK_YNEG,
@@ -85,7 +101,7 @@ s32 inputControllerMask(void);
 s32 inputKeyPressed(u32 vk);
 
 // idx is controller index, contbtn is one of the CONT_ constants
-s32 inputButtonPressed(s32 idx, u16 contbtn);
+s32 inputButtonPressed(s32 idx, u32 contbtn);
 
 // bind virtkey vk to n64 pad #idx's button/axis ck as represented by its contkey value
 // if bind is -1, picks a bind slot automatically

--- a/port/src/input.c
+++ b/port/src/input.c
@@ -73,6 +73,22 @@ static const char *ckNames[CK_TOTAL_COUNT] = {
 	"Z_TRIG",
 	"B_BUTTON",
 	"A_BUTTON",
+    "CK_0001",
+    "CK_0002",
+    "CK_0004",
+    "CK_0008",
+    "CK_0010",
+    "CK_0020",
+    "CK_0040",
+    "CK_0080",
+    "CK_0100",
+    "CK_0200",
+    "CK_0400",
+    "CK_0800",
+    "CK_1000",
+    "CK_2000",
+    "CK_4000",
+    "CK_8000"
 	"STICK_XNEG",
 	"STICK_XPOS",
 	"STICK_YNEG",
@@ -153,6 +169,8 @@ void inputSetDefaultKeyBinds(void)
 		{ CK_STICK_XPOS,    SDL_SCANCODE_RIGHT,  0                   },
 		{ CK_STICK_YNEG,    SDL_SCANCODE_DOWN,   0                   },
 		{ CK_STICK_YPOS,    SDL_SCANCODE_UP,     0                   },
+		{CK_4000,           SDL_SCANCODE_LSHIFT, 0                   },
+		{CK_2000,           SDL_SCANCODE_LCTRL, 0                    }
 	};
 
 	static const u32 joybinds[][2] = {
@@ -167,7 +185,7 @@ void inputSetDefaultKeyBinds(void)
 		{ CK_START,  SDL_CONTROLLER_BUTTON_START         },
 		{ CK_C_D,    SDL_CONTROLLER_BUTTON_DPAD_DOWN     },
 		{ CK_C_U,    SDL_CONTROLLER_BUTTON_DPAD_UP       },
-		{ CK_C_R,    SDL_CONTROLLER_BUTTON_DPAD_RIGHT    },
+		{ CK_8000,   SDL_CONTROLLER_BUTTON_LEFTSTICK     },
 		{ CK_C_L,    SDL_CONTROLLER_BUTTON_DPAD_LEFT     },
 	};
 
@@ -526,12 +544,6 @@ s32 inputReadController(s32 idx, OSContPad *npad)
 	rightX = inputAxisScale(rightX, deadzone[axisMap[1][0]], stickSens[axisMap[1][0]]);
 	rightY = inputAxisScale(rightY, deadzone[axisMap[1][1]], stickSens[axisMap[1][1]]);
 
-	if (stickCButtons) {
-		if (rightX < -0x4000) npad->button |= L_CBUTTONS;
-		if (rightX > +0x4000) npad->button |= R_CBUTTONS;
-		if (rightY < -0x4000) npad->button |= U_CBUTTONS;
-		if (rightY > +0x4000) npad->button |= D_CBUTTONS;
-	}
 
 	if (!npad->stick_x && leftX) {
 		npad->stick_x = leftX / 0x100;
@@ -542,9 +554,14 @@ s32 inputReadController(s32 idx, OSContPad *npad)
 		npad->stick_y = (stickY == 128) ? 127 : stickY;
 	}
 
-	stickY = -rightY / 0x100;
-	npad->rstick_y = (stickY == 128) ? 127 : stickY;
-	npad->rstick_x = rightX / 0x100;
+	if (!npad->rstick_x && rightX) {
+		npad->rstick_x = rightX / 0x100;
+	}
+
+	s32 rStickY = -rightY / 0x100;
+	if (!npad->rstick_y && rStickY) {
+		npad->rstick_y = (rStickY == 128) ? 127 : rStickY;
+	}
 
 	return 0;
 }
@@ -634,6 +651,7 @@ void inputKeyBind(s32 idx, u32 ck, s32 bind, u32 vk)
 		return;
 	}
 
+
 	if (bind < 0) {
 		for (s32 i = 0; i < MAX_BINDS; ++i) {
 			if (binds[idx][ck][i] == 0) {
@@ -673,7 +691,7 @@ s32 inputKeyPressed(u32 vk)
 	return 0;
 }
 
-static inline u16 inputContToContKey(const u16 cont)
+static inline u32 inputContToContKey(const u32 cont)
 {
 	if (cont == 0) {
 		return 0;
@@ -682,7 +700,7 @@ static inline u16 inputContToContKey(const u16 cont)
 	return 32 - __builtin_clz(cont - 1);
 }
 
-s32 inputButtonPressed(s32 idx, u16 contbtn)
+s32 inputButtonPressed(s32 idx, u32 contbtn)
 {
 	if (idx < 0 || idx >= INPUT_MAX_CONTROLLERS) {
 		return 0;

--- a/port/src/libultra.c
+++ b/port/src/libultra.c
@@ -196,6 +196,8 @@ void osContGetReadData(OSContPad *pad)
 		pad->button = 0;
 		pad->stick_x = 0;
 		pad->stick_y = 0;
+		pad->rstick_x = 0;
+		pad->rstick_y = 0;
 		if (inputReadController(i, pad) < 0) {
 			pad->errnum = CONT_NO_RESPONSE_ERROR;
 		} else {

--- a/src/game/activemenutick.c
+++ b/src/game/activemenutick.c
@@ -48,10 +48,12 @@ void amTick(void)
 				s8 gotonextscreen = false;
 				s8 cstickx = joyGetStickXOnSample(j, contpadnum);
 				s8 csticky = joyGetStickYOnSample(j, contpadnum);
+				s8 crstickx = joyGetRStickXOnSample(j, contpadnum);
+				s8 crsticky = joyGetRStickYOnSample(j, contpadnum);
 				s8 absstickx;
 				s8 abssticky;
-				u16 buttonsstate = joyGetButtonsOnSample(j, contpadnum, 0xffff);
-				u16 buttonspressed = joyGetButtonsPressedOnSample(j, contpadnum, 0xffff);
+				u32 buttonsstate = joyGetButtonsOnSample(j, contpadnum, 0xffffffff);
+				u32 buttonspressed = joyGetButtonsPressedOnSample(j, contpadnum, 0xffffffff);
 				bool stickpushed = false;
 				s32 slotnum;
 				bool stayopen;
@@ -77,8 +79,8 @@ void amTick(void)
 						am->mousex = (am->mousex > 127.f) ? 127.f : (am->mousex < -128.f) ? -128.f : am->mousex;
 						am->mousey = (am->mousey > 127.f) ? 127.f : (am->mousey < -128.f) ? -128.f : am->mousey;
 					}
-					const s32 newstickx = (s32)cstickx + (s32)am->mousex;
-					const s32 newsticky = (s32)csticky - (s32)am->mousey;
+					const s32 newstickx = (s32)cstickx + (s32)crstickx + (s32)am->mousex;
+					const s32 newsticky = (s32)csticky + (s32)crsticky - (s32)am->mousey;
 					cstickx = (newstickx < -128) ? -128 : (newstickx > 127) ? 127 : newstickx;
 					csticky = (newsticky < -128) ? -128 : (newsticky > 127) ? 127 : newsticky;
 				}
@@ -88,6 +90,8 @@ void amTick(void)
 					buttonsstate = buttonsstate & D_JPAD;
 					cstickx = 0;
 					csticky = 0;
+					crstickx = 0;
+					crsticky = 0;
 					buttonspressed = 0;
 				}
 
@@ -162,8 +166,8 @@ void amTick(void)
 					s8 contpadnum2 = optionsGetContpadNum2(g_Vars.currentplayerstats->mpindex);
 					s8 cstickx2 = joyGetStickXOnSample(j, contpadnum2);
 					s8 csticky2 = joyGetStickYOnSample(j, contpadnum2);
-					u16 buttonsstate2 = joyGetButtonsOnSample(j, contpadnum2, 0xffff);
-					u16 buttonspressed2 = joyGetButtonsPressedOnSample(j, contpadnum2, 0xffff);
+					u32 buttonsstate2 = joyGetButtonsOnSample(j, contpadnum2, 0xffffffff);
+					u32 buttonspressed2 = joyGetButtonsPressedOnSample(j, contpadnum2, 0xffffffff);
 
 					if (g_Vars.currentplayer->activemenumode == AMMODE_EDIT) {
 						buttonsstate2 = buttonsstate2 & D_JPAD;

--- a/src/game/bondeyespy.c
+++ b/src/game/bondeyespy.c
@@ -701,8 +701,8 @@ void eyespyProcessInput(bool allowbuttons)
 	s8 c2stickx;
 	s8 c1sticky = joyGetStickY(contpad1);
 	s8 c2sticky;
-	u16 c1buttons = allowbuttons ? joyGetButtons(contpad1, 0xffff) : 0;
-	u16 c2buttons;
+	u32 c1buttons = allowbuttons ? joyGetButtons(contpad1, 0xffffffff) : 0;
+	u32 c2buttons;
 	bool domovecentre = true;
 	s32 controlmode = optionsGetControlMode(g_Vars.currentplayerstats->mpindex);
 
@@ -726,10 +726,15 @@ void eyespyProcessInput(bool allowbuttons)
 		c2stickx = joyGetStickX(contpad2);
 		c2sticky = joyGetStickY(contpad2);
 
-		c2buttons = allowbuttons ? joyGetButtons(contpad2, 0xffff) : 0;
+		c2buttons = allowbuttons ? joyGetButtons(contpad2, 0xffffffff) : 0;
 	} else {
+		#ifndef PLATFORM_N64
+		c2stickx = joyGetRStickX(contpad1);
+		c2sticky = joyGetRStickY(contpad1);
+		#else
 		c2stickx = c1stickx;
 		c2sticky = c1sticky;
+		#endif
 		c2buttons = c1buttons;
 	}
 
@@ -833,9 +838,15 @@ void eyespyProcessInput(bool allowbuttons)
 		} else {
 			ascendspeed = c1sticky * 0.25f;
 			forwardspeed = (c1buttons & (U_CBUTTONS) ? 24.0f : 0) - (c1buttons & (D_CBUTTONS) ? 24.0f : 0);
+#ifndef PLATFORM_N64
+			forwardspeed += c2sticky;
+#endif
 		}
 
 		sidespeed = (c1buttons & (R_CBUTTONS) ? 1 : 0) - (c1buttons & (L_CBUTTONS) ? 1 : 0);
+#ifndef PLATFORM_N64
+		if (!sidespeed) sidespeed = c2stickx * 0.0125f;
+#endif
 	} else if (controlmode == CONTROLMODE_21 || controlmode == CONTROLMODE_23) {
 		forwardspeed = c1sticky;
 

--- a/src/game/bondview.c
+++ b/src/game/bondview.c
@@ -1367,8 +1367,8 @@ Gfx *bviewDrawEyespyMetrics(Gfx *gdl)
 
 	{
 		s8 contpadnum = optionsGetContpadNum1(g_Vars.currentplayerstats->mpindex);
-		u16 buttonsdown = joyGetButtons(contpadnum, 0xffff); \
-		u16 buttonsthisframe = joyGetButtonsPressedThisFrame(contpadnum, 0xffff);
+		u32 buttonsdown = joyGetButtons(contpadnum, 0xffffffff); \
+		u32 buttonsthisframe = joyGetButtonsPressedThisFrame(contpadnum, 0xffffffff);
 		s8 cstickx = joyGetStickX(contpadnum); \
 		s8 csticky = joyGetStickY(contpadnum);
 		s32 xpos;

--- a/src/game/bondwalk.c
+++ b/src/game/bondwalk.c
@@ -120,6 +120,10 @@ void bwalkInit(void)
 	}
 }
 
+void bwalkSetSwayTargetf(f32 value) {
+	g_Vars.currentplayer->swaytarget = value * 75.f;
+}
+
 void bwalkSetSwayTarget(s32 value)
 {
 	g_Vars.currentplayer->swaytarget = value * 75.0f;
@@ -1294,11 +1298,10 @@ void bwalkApplyMoveData(struct movedata *data)
 			bwalkUpdateSpeedSideways(1, 0.2f, data->digitalstepright);
 		} else if (data->unk14 == false) {
 			bwalkUpdateSpeedSideways(0, 0.2f, g_Vars.lvupdate60);
-		}
-
-		if (data->unk14) {
+		} else if (data->unk14){
 			bwalkUpdateSpeedSideways(data->analogstrafe * 0.014285714365542f, 0.2f, g_Vars.lvupdate60);
 		}
+
 
 		// Forward/back
 		if (data->digitalstepforward) {
@@ -1308,11 +1311,12 @@ void bwalkApplyMoveData(struct movedata *data)
 			bwalkUpdateSpeedForwards(-1, 1);
 		} else if (data->canlookahead == false) {
 			bwalkUpdateSpeedForwards(0, 1);
+		} else {
+			bwalkUpdateSpeedForwards(data->analogwalk * 0.014285714365542f, 1);
 		}
 
-		if (data->canlookahead) {
-			bwalkUpdateSpeedForwards(data->analogwalk * 0.014285714365542f, 1);
 
+		if (data->canlookahead) {
 			if (data->analogwalk > 60) {
 				g_Vars.currentplayer->speedmaxtime60 += g_Vars.lvupdate60;
 			} else {
@@ -1345,6 +1349,17 @@ void bwalkApplyMoveData(struct movedata *data)
 			g_Vars.currentplayer->speedmaxtime60 = 0;
 		}
 
+#ifndef PLATFORM_N64
+		if (data->rleanleft) {
+			bwalkSetSwayTarget(-1);
+		} else if (data->rleanright) {
+			bwalkSetSwayTarget(1);
+		} else if (fabsf(data->analoglean)) {
+			bwalkSetSwayTargetf(data->analoglean);
+		} else {
+			bwalkSetSwayTarget(0);
+		}
+#else
 		if (data->rleanleft) {
 			bwalkSetSwayTarget(-1);
 		} else if (data->rleanright) {
@@ -1352,6 +1367,7 @@ void bwalkApplyMoveData(struct movedata *data)
 		} else {
 			bwalkSetSwayTarget(0);
 		}
+#endif
 
 		while (data->crouchdown-- > 0) {
 			bwalkAdjustCrouchPos(-1);

--- a/src/game/debug2.c
+++ b/src/game/debug2.c
@@ -538,7 +538,7 @@ void debug0f11944cnb(void) // not called
 }
 #endif
 
-bool debugProcessInput(s8 stickx, s8 sticky, u16 buttons, u16 buttonsthisframe)
+bool debugProcessInput(s8 stickx, s8 sticky, u32 buttons, u32 buttonsthisframe)
 {
 #ifdef DEBUG
 	s32 i;

--- a/src/game/lv.c
+++ b/src/game/lv.c
@@ -2130,22 +2130,22 @@ void lvTick(void)
 	bgunTickBoost();
 	hudmsgsTick();
 
-	if ((joyGetButtonsPressedThisFrame(0, 0xffff) != 0
+	if ((joyGetButtonsPressedThisFrame(0, 0xffffffff) != 0
 				|| joyGetStickX(0) > 10
 				|| joyGetStickX(0) < -10
 				|| joyGetStickY(0) > 10
 				|| joyGetStickY(0) < -10
-				|| joyGetButtonsPressedThisFrame(1, 0xffff) != 0
+				|| joyGetButtonsPressedThisFrame(1, 0xffffffff) != 0
 				|| joyGetStickX(1) > 10
 				|| joyGetStickX(1) < -10
 				|| joyGetStickY(1) > 10
 				|| joyGetStickY(1) < -10
-				|| joyGetButtonsPressedThisFrame(2, 0xffff) != 0
+				|| joyGetButtonsPressedThisFrame(2, 0xffffffff) != 0
 				|| joyGetStickX(2) > 10
 				|| joyGetStickX(2) < -10
 				|| joyGetStickY(2) > 10
 				|| joyGetStickY(2) < -10
-				|| joyGetButtonsPressedThisFrame(3, 0xffff) != 0
+				|| joyGetButtonsPressedThisFrame(3, 0xffffffff) != 0
 				|| joyGetStickX(3) > 10
 				|| joyGetStickX(3) < -10
 				|| joyGetStickY(3) > 10
@@ -2159,22 +2159,22 @@ void lvTick(void)
 	}
 
 	if (g_Vars.stagenum < STAGE_TITLE && !g_IsTitleDemo && !g_Vars.in_cutscene) {
-		if (joyGetButtons(0, 0xffff) == 0
+		if (joyGetButtons(0, 0xffffffff) == 0
 				&& joyGetStickX(0) < 10
 				&& joyGetStickX(0) > -10
 				&& joyGetStickY(0) < 10
 				&& joyGetStickY(0) > -10
-				&& joyGetButtons(1, 0xffff) == 0
+				&& joyGetButtons(1, 0xffffffff) == 0
 				&& joyGetStickX(1) < 10
 				&& joyGetStickX(1) > -10
 				&& joyGetStickY(1) < 10
 				&& joyGetStickY(1) > -10
-				&& joyGetButtons(2, 0xffff) == 0
+				&& joyGetButtons(2, 0xffffffff) == 0
 				&& joyGetStickX(2) < 10
 				&& joyGetStickX(2) > -10
 				&& joyGetStickY(2) < 10
 				&& joyGetStickY(2) > -10
-				&& joyGetButtons(3, 0xffff) == 0
+				&& joyGetButtons(3, 0xffffffff) == 0
 				&& joyGetStickX(3) < 10
 				&& joyGetStickX(3) > -10
 				&& joyGetStickY(3) < 10

--- a/src/game/menu.c
+++ b/src/game/menu.c
@@ -4612,8 +4612,10 @@ void menuProcessInput(void)
 		for (i = 0; i < numcontpads; i++) {
 			s8 thisstickx = joyGetStickX(contpadnums[i]);
 			s8 thissticky = joyGetStickY(contpadnums[i]);
-			u16 buttons = joyGetButtons(contpadnums[i], 0xffff);
-			u16 buttonsnow = joyGetButtonsPressedThisFrame(contpadnums[i], 0xffff);
+			s8 thisrstickx = joyGetRStickX(contpadnums[i]);
+			s8 thisrsticky = joyGetRStickY(contpadnums[i]);
+			u32 buttons = joyGetButtons(contpadnums[i], 0xffffffff);
+			u32 buttonsnow = joyGetButtonsPressedThisFrame(contpadnums[i], 0xffffffff);
 
 			if (buttonsnow & A_BUTTON) {
 				inputs.select = 1;
@@ -4650,9 +4652,20 @@ void menuProcessInput(void)
 				stickx = thisstickx;
 			}
 
+#ifndef PLATFORM_N64
+			if ((stickx < 0 ? -stickx : stickx) < (thisrstickx < 0 ? -thisrstickx : thisrstickx)) {
+				stickx = thisrstickx;
+			}
+#endif
+
 			if ((sticky < 0 ? -sticky : sticky) < (thissticky < 0 ? -thissticky : thissticky)) {
 				sticky = thissticky;
 			}
+#ifndef PLATFORM_N64
+			if ((sticky < 0 ? -sticky : sticky) < (thisrsticky < 0 ? -thisrsticky : thisrsticky)) {
+				sticky = thisrsticky;
+			}
+#endif
 
 			if (buttons & U_CBUTTONS) {
 				yhelddir = -1;

--- a/src/game/menutick.c
+++ b/src/game/menutick.c
@@ -334,7 +334,7 @@ void menuTick(void)
 				if (g_MenuData.root == MENUROOT_MPSETUP || g_MenuData.root == MENUROOT_4MBMAINMENU) {
 					// Check if player is joining the game
 					bool canjoin;
-					u16 buttons = joyGetButtonsPressedThisFrame(i, 0xffff);
+					u32 buttons = joyGetButtonsPressedThisFrame(i, 0xffffffff);
 
 					if (g_MenuData.root == MENUROOT_4MBMAINMENU) {
 						if (g_Vars.mpsetupmenu == MPSETUPMENU_GENERAL) {
@@ -428,7 +428,7 @@ void menuTick(void)
 				// Note that MPENDSCREEN also refers to coop and anti modes.
 				// Handle re-opening the endscreen by pressing B.
 				if (g_MenuData.root == MENUROOT_MPENDSCREEN) {
-					u16 buttons2 = joyGetButtonsPressedThisFrame(g_PlayerConfigsArray[i].contpad1, 0xffff);
+					u32 buttons2 = joyGetButtonsPressedThisFrame(g_PlayerConfigsArray[i].contpad1, 0xffffffff);
 
 					if (buttons2 & B_BUTTON) {
 						s32 playernum = -1;

--- a/src/game/player.c
+++ b/src/game/player.c
@@ -1897,7 +1897,7 @@ void playerTickCutscene(bool arg0)
 	f32 fovy;
 	s32 endframe;
 	s8 contpadnum = optionsGetContpadNum1(g_Vars.currentplayerstats->mpindex);
-	u16 buttons;
+	u32 buttons;
 #if PAL
 	u8 stack3[0x2c];
 #endif
@@ -1910,7 +1910,7 @@ void playerTickCutscene(bool arg0)
 	f32 sp54[4];
 
 	if (arg0) {
-		buttons = joyGetButtons(contpadnum, 0xffff);
+		buttons = joyGetButtons(contpadnum, 0xffffffff);
 	} else {
 		buttons = 0;
 	}
@@ -2029,7 +2029,7 @@ void playerTickCutscene(bool arg0)
 	}
 
 #if VERSION >= VERSION_NTSC_1_0
-	if (g_CutsceneCurTotalFrame60f > 30 && (buttons & 0xffff)) {
+	if (g_CutsceneCurTotalFrame60f > 30 && (buttons & 0xffffffff)) {
 		g_CutsceneSkipRequested = true;
 
 		if (g_Vars.autocutplaying) {
@@ -2042,7 +2042,7 @@ void playerTickCutscene(bool arg0)
 	}
 #else
 	if (g_CutsceneCurTotalFrame60f > 30) {
-		if (buttons & 0xffff) {
+		if (buttons & 0xffffffff) {
 			g_CutsceneSkipRequested = true;
 		}
 
@@ -3300,7 +3300,7 @@ void playerTick(bool arg0)
 				if (g_Vars.currentplayer->eyespy->active) {
 					// And is being controlled
 					s8 contpad1 = optionsGetContpadNum1(g_Vars.currentplayerstats->mpindex);
-					u16 buttons = arg0 ? joyGetButtons(contpad1, 0xffff) : 0;
+					u32 buttons = arg0 ? joyGetButtons(contpad1, 0xffffffff) : 0;
 
 					if (g_Vars.currentplayer->isdead == false
 							&& g_Vars.currentplayer->pausemode == PAUSEMODE_UNPAUSED
@@ -3491,6 +3491,9 @@ void playerTick(bool arg0)
 				s8 contpad2 = optionsGetContpadNum2(g_Vars.currentplayerstats->mpindex);
 				s8 stickx = 0;
 				s8 sticky = 0;
+#ifndef PLATFORM_N64
+				s8 rsticky = joyGetRStickY(contpad1);
+#endif
 				Mtxf sp1fc;
 				Mtxf sp1bc;
 				Mtxf sp17c;
@@ -3507,6 +3510,7 @@ void playerTick(bool arg0)
 				f32 sp11c[3];
 #endif
 				bool explode = false;
+				// NOTE: slayer handling
 				bool slow = false;
 				bool pause = false;
 				f32 newspeed;
@@ -3659,6 +3663,16 @@ void playerTick(bool arg0)
 					targetspeed = 12;
 				}
 
+#ifndef PLATFORM_N64
+				targetspeed += rsticky / 127.f * 12.f;
+				if (targetspeed > 12) {
+					targetspeed = 12;
+				}
+				if (targetspeed < 1) {
+					targetspeed = 1;
+				}
+#endif
+				
 				newspeed = prevspeed;
 
 				if (prevspeed < targetspeed) {

--- a/src/game/title.c
+++ b/src/game/title.c
@@ -731,7 +731,7 @@ void titleTickPdLogo(void)
 		titleSetNextMode(TITLEMODE_SKIP);
 	}
 
-	if (joyGetButtonsPressedThisFrame(0, 0xffff)) {
+	if (joyGetButtonsPressedThisFrame(0, 0xffffffff)) {
 		g_TitleButtonPressed = g_TitleFastForward = true;
 
 		if (g_TitleTimer < TICKS(549)) {
@@ -1694,7 +1694,7 @@ void titleTickRarePresents(void)
 
 	if (g_TitleTimer > TICKS(300)) {
 		titleSetNextMode(TITLEMODE_PDLOGO);
-	} else if (joyGetButtonsPressedThisFrame(0, 0xffff)) {
+	} else if (joyGetButtonsPressedThisFrame(0, 0xffffffff)) {
 		titleSetNextMode(TITLEMODE_SKIP);
 	}
 }
@@ -1848,7 +1848,7 @@ void titleTickNintendoLogo(void)
 		g_TitleTimer += g_Vars.lvupdate60;
 	}
 
-	if (joyGetButtonsPressedThisFrame(0, 0xffff)) {
+	if (joyGetButtonsPressedThisFrame(0, 0xffffffff)) {
 		if (osResetType == RESETTYPE_WARM) {
 			g_TitleButtonPressed = true;
 			titleSetNextMode(TITLEMODE_PDLOGO);
@@ -2021,7 +2021,7 @@ void titleTickRareLogo(void)
 
 		g_TitleTimer += g_Vars.lvupdate60;
 
-		if (joyGetButtonsPressedThisFrame(0, 0xffff)) {
+		if (joyGetButtonsPressedThisFrame(0, 0xffffffff)) {
 			if (osResetType == RESETTYPE_WARM) {
 				g_TitleButtonPressed = true;
 				titleSetNextMode(TITLEMODE_PDLOGO);

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -4689,6 +4689,10 @@ enum weaponnum {
 #define BUTTON_RADIAL         D_JPAD
 #define BUTTON_ALTMODE        L_TRIG
 
+#define BUTTON_CROUCH_CYCLE   CONT_8000             
+#define BUTTON_HALF_CROUCH    CONT_4000             
+#define BUTTON_FULL_CROUCH    CONT_2000             
+
 #define MOUSEAIM_CLASSIC 0 // crosshair moves around the screen in aim mode
 #define MOUSEAIM_LOCKED 1  // crosshair locked to the center of the screen in aim mode
 

--- a/src/include/game/bondwalk.h
+++ b/src/include/game/bondwalk.h
@@ -6,6 +6,7 @@
 
 void bwalkInit(void);
 void bwalkSetSwayTarget(s32 value);
+void bwalkSetSwayTargetf(f32 value);
 void bwalkAdjustCrouchPos(s32 value);
 void bwalk0f0c3b38(struct coord *param_1, struct defaultobj *obj);
 s32 bwalkTryMoveUpwards(f32 amount);

--- a/src/include/game/debug.h
+++ b/src/include/game/debug.h
@@ -46,7 +46,7 @@ void dmenuNavigateDown(void);
 Gfx *dmenuRender(Gfx *gdl);
 
 void debugUpdateMenu(void);
-bool debugProcessInput(s8 stickx, s8 sticky, u16 buttons, u16 buttonsthisframe);
+bool debugProcessInput(s8 stickx, s8 sticky, u32 buttons, u32 buttonsthisframe);
 bool debugIsLineModeEnabled(void);
 
 extern s32 var800786f4nb;

--- a/src/include/lib/joy.h
+++ b/src/include/lib/joy.h
@@ -26,16 +26,21 @@ void joyReadData(void);
 void joysHandleRetrace(void);
 void joy00014810(bool value);
 s32 joyGetNumSamples(void);
+s32 joyGetRStickXOnSample(s32 samplenum, s8 contpadnum);
+s32 joyGetRStickYOnSample(s32 samplenum, s8 contpadnum);
 s32 joyGetStickXOnSample(s32 samplenum, s8 contpadnum);
 s32 joyGetStickYOnSample(s32 samplenum, s8 contpadnum);
 s32 joyGetStickYOnSampleIndex(s32 samplenum, s8 contpadnum);
-u16 joyGetButtonsOnSample(s32 samplenum, s8 contpadnum, u16 mask);
-u16 joyGetButtonsPressedOnSample(s32 samplenum, s8 contpadnum, u16 mask);
-s32 joyCountButtonsOnSpecificSamples(u32 *arg0, s8 contpadnum, u16 mask);
+s32 joyGetRStickYOnSampleIndex(s32 samplenum, s8 contpadnum);
+u32 joyGetButtonsOnSample(s32 samplenum, s8 contpadnum, u32 mask);
+u32 joyGetButtonsPressedOnSample(s32 samplenum, s8 contpadnum, u32 mask);
+s32 joyCountButtonsOnSpecificSamples(u32 *arg0, s8 contpadnum, u32 mask);
 s8 joyGetStickX(s8 contpadnum);
 s8 joyGetStickY(s8 contpadnum);
-u16 joyGetButtons(s8 contpadnum, u16 mask);
-u16 joyGetButtonsPressedThisFrame(s8 contpadnum, u16 mask);
+s8 joyGetRStickX(s8 contpadnum);
+s8 joyGetRStickY(s8 contpadnum);
+u32 joyGetButtons(s8 contpadnum, u32 mask);
+u32 joyGetButtonsPressedThisFrame(s8 contpadnum, u32 mask);
 bool joyIsCyclicPollingEnabled(void);
 
 #if VERSION >= VERSION_NTSC_1_0

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -5076,6 +5076,7 @@ struct movedata {
 #ifndef PLATFORM_N64
 	/*    */ f32 freelookdx; // how much the mouse moved ...
 	/*    */ f32 freelookdy; // ... scaled by sensitivity
+	/*    */ f32 analoglean; // how much we're trying to lean
 #endif
 
 };

--- a/src/lib/main.c
+++ b/src/lib/main.c
@@ -1028,11 +1028,11 @@ void mainTick(void)
 
 #ifdef DEBUG
 			if (g_MainIsDebugMenuOpen || joyGetButtons(0, U_CBUTTONS | D_CBUTTONS) == (U_CBUTTONS | D_CBUTTONS)) {
-				g_MainIsDebugMenuOpen = debugProcessInput(joyGetStickX(0), joyGetStickY(0), joyGetButtons(0, 0xffff), joyGetButtonsPressedThisFrame(0, 0xffff));
+				g_MainIsDebugMenuOpen = debugProcessInput(joyGetStickX(0), joyGetStickY(0), joyGetButtons(0, 0xffffffff), joyGetButtonsPressedThisFrame(0, 0xffffffff));
 			} else if (joyGetButtons(0, START_BUTTON) == 0) {
 				var80075d68 = var800786f4nb;
 			} else {
-				g_MainIsDebugMenuOpen = debugProcessInput(joyGetStickX(0), joyGetStickY(0), joyGetButtons(0, 0xffff), joyGetButtonsPressedThisFrame(0, 0xffff));
+				g_MainIsDebugMenuOpen = debugProcessInput(joyGetStickX(0), joyGetStickY(0), joyGetButtons(0, 0xffffffff), joyGetButtonsPressedThisFrame(0, 0xffffffff));
 			}
 #endif
 

--- a/src/lib/ultra/io/controller.h
+++ b/src/lib/ultra/io/controller.h
@@ -19,7 +19,7 @@ typedef struct
 	/* 0x1 */ u8 txsize;
 	/* 0x2 */ u8 rxsize;
 	/* 0x3 */ u8 cmd;
-	/* 0x4 */ u16 button;
+	/* 0x4 */ u32 button;
 	/* 0x6 */ s8 stick_x;
 	/* 0x7 */ s8 stick_y;
 } __OSContReadFormat;


### PR DESCRIPTION
This PR enables the second analog stick to be used as though it were attached to the same controller. This allows all four players to use the 1.2 configuration and have a true 2.2/Xbox-style experience. 

Also, the game's controller handling was expanded to allow for up to 32 buttons. A follow-up update could segregate the N64 buttons away from the PC-exclusive buttons.

- Implements https://github.com/fgsfdsfgs/perfect_dark/issues/184
- Partially implements https://github.com/fgsfdsfgs/perfect_dark/issues/42