### PR TITLE
Allow mouse input by default

### DIFF
--- a/port/include/input.h
+++ b/port/include/input.h
@@ -173,4 +173,7 @@ void inputSetDefaultKeyBinds(void);
 void inputClearLastKey(void);
 s32 inputGetLastKey(void);
 
+s32 inputGetMouseDefaultLocked(void);
+void inputSetMouseDefaultLocked(s32 defaultLocked);
+
 #endif

--- a/port/src/input.c
+++ b/port/src/input.c
@@ -26,6 +26,7 @@ static s32 connectedMask = 0;
 
 static s32 mouseEnabled = 1;
 static s32 mouseLocked = 0;
+static s32 mouseDefaultLocked = 0;
 static s32 mouseX, mouseY;
 static s32 mouseDX, mouseDY;
 static u32 mouseButtons;
@@ -459,6 +460,7 @@ void inputSaveConfig(void)
 	inputSaveBinds();
 
 	configSetInt("Input.MouseEnabled", mouseEnabled);
+    configSetInt("Input.MouseDefaultLocked", mouseDefaultLocked);
 	configSetFloat("Input.MouseSpeedX", mouseSensX);
 	configSetFloat("Input.MouseSpeedY", mouseSensY);
 
@@ -513,6 +515,8 @@ s32 inputInit(void)
 	inputSetDefaultKeyBinds();
 
 	mouseEnabled = configGetInt("Input.MouseEnabled", 1);
+	mouseDefaultLocked = configGetInt("Input.MouseDefaultLocked", 0);
+	inputLockMouse(mouseDefaultLocked);
 	mouseSensX = configGetFloat("Input.MouseSpeedX", 1.5f);
 	mouseSensY = configGetFloat("Input.MouseSpeedY", 1.5f);
 
@@ -929,6 +933,18 @@ void inputMouseEnable(s32 enabled)
 	}
 }
 
+s32 inputGetMouseDefaultLocked(void)
+{
+	return mouseDefaultLocked;
+}
+
+void inputSetMouseDefaultLocked(s32 defaultLocked)
+{
+	mouseDefaultLocked = !!defaultLocked;
+	if (mouseEnabled) {
+		inputLockMouse(mouseDefaultLocked);
+	}
+}
 
 const char *inputGetContKeyName(u32 ck)
 {

--- a/port/src/optionsmenu.c
+++ b/port/src/optionsmenu.c
@@ -42,6 +42,19 @@ static MenuItemHandlerResult menuhandlerMouseAimLock(s32 operation, struct menui
 	return 0;
 }
 
+static MenuItemHandlerResult menuhandlerMouseDefaultLocked(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+	switch (operation) {
+	case MENUOP_GET:
+		return inputGetMouseDefaultLocked();
+	case MENUOP_SET:
+		inputSetMouseDefaultLocked(data->checkbox.value);
+		break;
+	}
+
+	return 0;
+}
+
 static MenuItemHandlerResult menuhandlerMouseSpeedX(s32 operation, struct menuitem *item, union handlerdata *data)
 {
 	f32 x, y;
@@ -167,6 +180,14 @@ struct menuitem g_ExtendedMouseMenuItems[] = {
 		(uintptr_t)"Mouse Aim Lock",
 		0,
 		menuhandlerMouseAimLock,
+	},
+	{
+		MENUITEMTYPE_CHECKBOX,
+		0,
+		MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"Grab Mouse Input by Default",
+		0,
+		menuhandlerMouseDefaultLocked,
 	},
 	{
 		MENUITEMTYPE_SEPARATOR,


### PR DESCRIPTION
Noticed that mouse input wasn't tracked by default, always had to do one click to get it working.
Upon inspection it seems like it was done on purpose (mouse click locks mouse input, escape key unlocks it) but I added option for the mouse to be grabbed - locked by default.