### PR TITLE
Remote mine fixes

### DIFF
--- a/src/game/activemenu.c
+++ b/src/game/activemenu.c
@@ -364,7 +364,12 @@ void amApply(s32 slot)
 							bgunEquipWeapon2(HAND_RIGHT, weaponnum);
 						}
 
-						if (bgunGetWeaponNum(HAND_LEFT) != WEAPON_NONE) {
+						// don't unequip detonator
+						// if we already have it equipped
+						if (weaponnum == WEAPON_REMOTEMINE) {
+							bgunEquipWeapon2(HAND_LEFT, weaponnum);
+						}
+						else if (bgunGetWeaponNum(HAND_LEFT) != WEAPON_NONE) {
 							bgunEquipWeapon2(HAND_LEFT, WEAPON_NONE);
 						}
 					}

--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -51,6 +51,9 @@ static void bgunProcessQuickDetonate(struct movedata *data, u32 c1buttons, u32 c
 		data->weaponbackoffset = 0;
 		data->weaponforwardoffset = 0;
 		data->btapcount = 0;
+		// prevent the previous slotnum
+		// from causing Jo to switch weapons
+		g_AmMenus[g_AmIndex].slotnum = 4;
 		amClose();
 		g_Vars.currentplayer->invdowntime = -2;
 		g_Vars.currentplayer->usedowntime = -2;

--- a/src/game/mainmenu.c
+++ b/src/game/mainmenu.c
@@ -4304,7 +4304,14 @@ MenuItemHandlerResult menuhandlerInventoryList(s32 operation, struct menuitem *i
 					bgunEquipWeapon2(HAND_LEFT, weaponnum);
 				} else {
 					bgunEquipWeapon2(HAND_RIGHT, weaponnum);
-					bgunEquipWeapon2(HAND_LEFT, WEAPON_NONE);
+					// don't unequip detonator
+					// if we already have it equipped
+					if (weaponnum == WEAPON_REMOTEMINE) {
+						bgunEquipWeapon2(HAND_LEFT, weaponnum);
+					}
+					else{
+						bgunEquipWeapon2(HAND_LEFT, WEAPON_NONE);
+					}
 				}
 			}
 


### PR DESCRIPTION
- N64 fix: fixes issue where selecting the remote mine from the active menu or the inventory menu when Jo already has a remote mine equipped causes the player to unequip the detonator

Confirmed this issue presents on ntsc-final on 1964GEPD.

- port fix: fixes issue with remote mine input handler where the previous active menu slotnum would be activeated. The slotnum is unconditionally set to 4 (the "resting no-op" slotnum) to prevent this