### PR TITLE
Add option to unlock everything (Cheats, levels, weapons, challenges, bots, etc)

### DIFF
--- a/port/src/main.c
+++ b/port/src/main.c
@@ -139,6 +139,7 @@ PD_CONSTRUCTOR static void gameConfigInit(void)
 	configRegisterInt("Game.CenterHUD", &g_HudCenter, 0, 1);
 	configRegisterFloat("Game.ScreenShakeIntensity", &g_ViShakeIntensityMult, 0.f, 10.f);
 	configRegisterInt("Game.TickRateDivisor", &g_TickRateDiv, 0, 10);
+	configRegisterInt("Game.UnlockEverything", &g_UnlockEverything, 0, 1);
 	for (s32 j = 0; j < MAX_PLAYERS; ++j) {
 		const s32 i = j + 1;
 		configRegisterFloat(strFmt("Game.Player%d.FovY", i), &g_PlayerExtCfg[j].fovy, 5.f, 175.f);

--- a/port/src/main.c
+++ b/port/src/main.c
@@ -36,6 +36,7 @@ u32 g_VmNumPageReplaces = 0;
 u8 g_VmShowStats = 0;
 
 s32 g_TickRateDiv = 1;
+s32 g_UnlockEverything = false;
 
 extern s32 g_StageNum;
 

--- a/port/src/optionsmenu.c
+++ b/port/src/optionsmenu.c
@@ -792,14 +792,6 @@ struct menuitem g_ExtendedGameMenuItems[] = {
 		menuhandlerClassicCrouch,
 	},
 	{
-		MENUITEMTYPE_CHECKBOX,
-		0,
-		MENUITEMFLAG_LITERAL_TEXT,
-		(uintptr_t)"Unlock Everything",
-		0,
-		menuhandlerUnlockEverything,
-	},
-	{
 		MENUITEMTYPE_SLIDER,
 		0,
 		MENUITEMFLAG_LITERAL_TEXT,
@@ -1121,6 +1113,14 @@ struct menuitem g_ExtendedMenuItems[] = {
 		(uintptr_t)"Key Bindings\n",
 		0,
 		menuhandlerOpenBindsMenu,
+	},
+	{
+		MENUITEMTYPE_CHECKBOX,
+		0,
+		MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"Unlock Everything",
+		0,
+		menuhandlerUnlockEverything,
 	},
 	{
 		MENUITEMTYPE_SEPARATOR,

--- a/port/src/optionsmenu.c
+++ b/port/src/optionsmenu.c
@@ -640,6 +640,19 @@ static MenuItemHandlerResult menuhandlerCenterHUD(s32 operation, struct menuitem
 	return 0;
 }
 
+static MenuItemHandlerResult menuhandlerUnlockEverything(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+	switch (operation) {
+	case MENUOP_GET:
+		return g_UnlockEverything;
+	case MENUOP_SET:
+		g_UnlockEverything = data->checkbox.value;
+		break;
+	}
+	
+	return 0;
+}
+
 static MenuItemHandlerResult menuhandlerScreenShake(s32 operation, struct menuitem *item, union handlerdata *data)
 {
 	switch (operation) {
@@ -777,6 +790,14 @@ struct menuitem g_ExtendedGameMenuItems[] = {
 		(uintptr_t)"Allow Classic Crouch",
 		0,
 		menuhandlerClassicCrouch,
+	},
+	{
+		MENUITEMTYPE_CHECKBOX,
+		0,
+		MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"Unlock Everything",
+		0,
+		menuhandlerUnlockEverything,
 	},
 	{
 		MENUITEMTYPE_SLIDER,

--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -12223,6 +12223,10 @@ bool bgunAmmotypeAllowsUnlimitedAmmo(u32 ammotype)
 		}
 		break;
 	case AMMOTYPE_PSYCHOSIS:
+		if (g_UnlockEverything)
+			return true;
+		else
+			return false;
 	case AMMOTYPE_17:
 	case AMMOTYPE_BUG:
 	case AMMOTYPE_MICROCAMERA:

--- a/src/game/challenge.c
+++ b/src/game/challenge.c
@@ -99,7 +99,9 @@ void challengeDetermineUnlockedFeatures(void)
 	for (challengeindex = 0; challengeindex < ARRAYCOUNT(g_MpChallenges); challengeindex++) {
 		flag = 0;
 
-		if (challengeIsCompletedByAnyPlayerWithNumPlayers(challengeindex, 1)
+		if (g_UnlockEverything) {
+			flag = 1;
+		} else if (challengeIsCompletedByAnyPlayerWithNumPlayers(challengeindex, 1)
 				|| challengeIsCompletedByAnyPlayerWithNumPlayers(challengeindex, 2)
 				|| challengeIsCompletedByAnyPlayerWithNumPlayers(challengeindex, 3)
 				|| challengeIsCompletedByAnyPlayerWithNumPlayers(challengeindex, 4)) {
@@ -214,7 +216,9 @@ void challengeDetermineUnlockedFeatures(void)
 	for (j = 0; j < func0f188bcc(); j++) {
 		struct mpweapon *weapon = &g_MpWeapons[j];
 
-		if (weapon->unlockfeature > 0 && func0f19cbcc(weapon->weaponnum)) {
+		if (g_UnlockEverything) {
+			g_MpFeaturesUnlocked[weapon->unlockfeature] |= 1;
+		} else if (weapon->unlockfeature > 0 && func0f19cbcc(weapon->weaponnum)) {
 			g_MpFeaturesUnlocked[weapon->unlockfeature] |= 1;
 		}
 	}
@@ -770,6 +774,9 @@ bool challengeIsCompletedByAnyPlayerWithNumPlayers(s32 index, s32 numplayers)
 
 void challengeSetCompletedByAnyPlayerWithNumPlayers(s32 index, s32 numplayers, bool completed)
 {
+	if (g_UnlockEverything)
+		completed = true;
+	
 	if (completed) {
 		g_MpChallenges[index].completions[numplayers - 1] |= 1;
 		return;

--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -107,6 +107,9 @@ u32 cheatIsUnlocked(s32 cheat_id)
 	struct cheat *cheat = &g_Cheats[cheat_id];
 	u32 unlocked = 0;
 
+	if (g_UnlockEverything)
+		return 1;
+	
 	if (cheat->flags & CHEATFLAG_FIRINGRANGE) {
 		if (frIsClassicWeaponUnlocked(cheat->time)) {
 			unlocked++;

--- a/src/game/invitems.c
+++ b/src/game/invitems.c
@@ -2270,7 +2270,7 @@ struct weaponfunc_shootauto invfunc_k7avenger_threatdetector = {
 	0, // ammoindex
 	&invnoisesettings_louder,
 	NULL, // fire animation
-	FUNCFLAG_BURST3 | FUNCFLAG_NOMUZZLEFLASH | FUNCFLAG_THREATDETECTOR,
+	FUNCFLAG_BURST3 | FUNCFLAG_THREATDETECTOR,
 	&invrecoilsettings_default,
 	0, // recoverytime60
 	1.5, // damage

--- a/src/game/mainmenu.c
+++ b/src/game/mainmenu.c
@@ -965,6 +965,9 @@ bool isStageDifficultyUnlocked(s32 stageindex, s32 difficulty)
 	s32 s;
 	s32 d;
 
+	if (g_UnlockEverything)
+		return true;
+	
 	// Handle special missions
 	if (stageindex > SOLOSTAGEINDEX_SKEDARRUINS) {
 #if VERSION >= VERSION_NTSC_1_0

--- a/src/game/mainmenu.c
+++ b/src/game/mainmenu.c
@@ -1149,6 +1149,11 @@ MenuItemHandlerResult menuhandlerPdMode(s32 operation, struct menuitem *item, un
 		menuPushDialog(&g_PdModeSettingsMenuDialog);
 		break;
 	case MENUOP_CHECKHIDDEN:
+
+		if (g_UnlockEverything) {
+			return false;
+		}
+		
 		if (g_GameFile.besttimes[SOLOSTAGEINDEX_SKEDARRUINS][DIFF_PA] == 0) {
 			return true;
 		}
@@ -1775,7 +1780,7 @@ s32 getNumUnlockedSpecialStages(void)
 	s32 i;
 
 	for (i = 0; i < ARRAYCOUNT(g_GameFile.besttimes[0]); i++) {
-		if (g_GameFile.besttimes[SOLOSTAGEINDEX_SKEDARRUINS][i]) {
+		if (g_GameFile.besttimes[SOLOSTAGEINDEX_SKEDARRUINS][i] || g_UnlockEverything) {
 			count = i + 1;
 		}
 	}
@@ -1790,6 +1795,9 @@ s32 getNumUnlockedSpecialStages(void)
 		}
 	}
 
+	if (g_UnlockEverything)
+		offsetforduel = 1;
+	
 	return count + offsetforduel;
 }
 
@@ -1799,7 +1807,7 @@ s32 func0f104720(s32 value)
 	s32 d;
 
 	for (d = 0; d < ARRAYCOUNT(g_GameFile.besttimes[0]); d++) {
-		if (g_GameFile.besttimes[SOLOSTAGEINDEX_SKEDARRUINS][d]) {
+		if (g_GameFile.besttimes[SOLOSTAGEINDEX_SKEDARRUINS][d] || g_UnlockEverything) {
 			next = d + 1;
 		}
 	}
@@ -1868,6 +1876,10 @@ MenuItemHandlerResult menuhandlerMissionList(s32 operation, struct menuitem *ite
 
 			data->list.value++;
 
+			if (g_UnlockEverything){
+				stageiscomplete = true;
+			}
+			
 			if (!stageiscomplete) {
 				break;
 			}

--- a/src/include/data.h
+++ b/src/include/data.h
@@ -546,6 +546,7 @@ extern s32 g_PrevFrameFb;
 extern s32 g_BlurFb;
 extern s32 g_BlurFbCapTimer;
 extern s32 g_TickRateDiv;
+extern s32 g_UnlockEverything;
 
 #define PLAYER_EXTCFG() g_PlayerExtCfg[g_Vars.currentplayerstats->mpindex & 3]
 #define PLAYER_DEFAULT_FOV (PLAYER_EXTCFG().fovy)


### PR DESCRIPTION
As mentioned in https://github.com/fgsfdsfgs/perfect_dark/issues/233

This will allow all unlockables to be unlocked with an in-game menu option.

I tested and everything appears to be working correctly except single player levels and challenges.  I'll work on getting those working and added to this PR.

I also need move the menu out of the per-player settings as it is a global option.  I wasn't sure where the best place for it should be.