### PR TITLE
Add the minimal required gcc and sdl2 version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Controls can be rebound in `pd.ini`. Default control scheme is as follows:
 
 ### Linux
 
-1. Ensure you have gcc, g++ (both >=10) and 32-bit versions of SDL2 (>=2.0.14), libGL and ZLib installed on your system.
+1. Ensure you have gcc, g++ (both >=10) and 32-bit versions of SDL2 (>=2.0.12), libGL and ZLib installed on your system.
    * On a 64-bit system you also need to have `gcc-multilib` and `g++-multilib` (or your distro's analogues) installed.
 2. Run the following command in the `perfect_dark` directory:
    * On a 64-bit system: ```make -f Makefile.port TARGET_PLATFORM=i686-linux```

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Controls can be rebound in `pd.ini`. Default control scheme is as follows:
 
 ### Linux
 
-1. Ensure you have gcc, g++ and 32-bit versions of SDL2, libGL and ZLib installed on your system.
+1. Ensure you have gcc, g++ (both >=10) and 32-bit versions of SDL2 (>=2.0.14), libGL and ZLib installed on your system.
    * On a 64-bit system you also need to have `gcc-multilib` and `g++-multilib` (or your distro's analogues) installed.
 2. Run the following command in the `perfect_dark` directory:
    * On a 64-bit system: ```make -f Makefile.port TARGET_PLATFORM=i686-linux```


### PR DESCRIPTION
I building the game on Ubuntu 20.04 (which is relatively not that old), which has gcc9 and libsdl2-2.0.12 installed by default. And I found at least gcc10 is required for c++20 support used in fast3d, and libsdl2 require 2.0.14 to successfully build or would be missing some symbols otherwise.
It would be nice to let people know the minimal version required so that they know which version to upgrade to when working on a system without latest packages.