### PR TITLE
port: add start window maximized flag to config

### DIFF
--- a/port/fast3d/gfx_api.h
+++ b/port/fast3d/gfx_api.h
@@ -31,7 +31,7 @@ extern float gfx_current_native_aspect; // The aspect ratio of the above mode
 extern bool gfx_framebuffers_enabled;
 
 void gfx_init(struct GfxWindowManagerAPI* wapi, struct GfxRenderingAPI* rapi, const char* game_name,
-              bool start_in_fullscreen, uint32_t width, uint32_t height,
+              bool start_in_fullscreen, bool start_maximized, uint32_t width, uint32_t height,
               uint32_t posX, uint32_t posY);
 void gfx_destroy(void);
 struct GfxRenderingAPI* gfx_get_current_rendering_api(void);

--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -2699,10 +2699,10 @@ extern "C" void gfx_get_dimensions(uint32_t* width, uint32_t* height, int32_t* p
 }
 
 extern "C" void gfx_init(struct GfxWindowManagerAPI* wapi, struct GfxRenderingAPI* rapi, const char* game_name,
-              bool start_in_fullscreen, uint32_t width, uint32_t height, uint32_t posX, uint32_t posY) {
+              bool start_in_fullscreen, bool start_maximized, uint32_t width, uint32_t height, uint32_t posX, uint32_t posY) {
     gfx_wapi = wapi;
     gfx_rapi = rapi;
-    gfx_wapi->init(game_name, rapi->get_name(), start_in_fullscreen, width, height, posX, posY);
+    gfx_wapi->init(game_name, rapi->get_name(), start_in_fullscreen, start_maximized, width, height, posX, posY);
     gfx_rapi->init();
     gfx_rapi->update_framebuffer_parameters(0, width, height, 1, false, true, true, true);
     gfx_current_dimensions.internal_mul = 1;

--- a/port/fast3d/gfx_sdl2.cpp
+++ b/port/fast3d/gfx_sdl2.cpp
@@ -84,7 +84,7 @@ static void gfx_sdl_get_active_window_refresh_rate(uint32_t* refresh_rate) {
     *refresh_rate = mode.refresh_rate;
 }
 
-static void gfx_sdl_init(const char* game_name, const char* gfx_api_name, bool start_in_fullscreen, uint32_t width,
+static void gfx_sdl_init(const char* game_name, const char* gfx_api_name, bool start_in_fullscreen, bool start_maximized, uint32_t width,
                          uint32_t height, int32_t posX, int32_t posY) {
     window_width = width;
     window_height = height;
@@ -110,7 +110,11 @@ static void gfx_sdl_init(const char* game_name, const char* gfx_api_name, bool s
         posY = 100;
     }
 
-    const Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_OPENGL;
+    Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_OPENGL;
+    if (start_maximized) {
+        flags |= SDL_WINDOW_MAXIMIZED;
+    }
+
     wnd = SDL_CreateWindow(title, posX, posY, window_width, window_height, flags);
     if (!wnd) {
         sysFatalError("Could not open SDL window:\n%s", SDL_GetError());

--- a/port/fast3d/gfx_window_manager_api.h
+++ b/port/fast3d/gfx_window_manager_api.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 
 struct GfxWindowManagerAPI {
-    void (*init)(const char* game_name, const char* gfx_api_name, bool start_in_fullscreen, uint32_t width,
+    void (*init)(const char* game_name, const char* gfx_api_name, bool start_in_fullscreen, bool start_maximized, uint32_t width,
                  uint32_t height, int32_t posX, int32_t posY);
     void (*close)(void);
     void (*set_fullscreen_changed_callback)(void (*on_fullscreen_changed)(bool is_now_fullscreen));

--- a/port/src/video.c
+++ b/port/src/video.c
@@ -21,6 +21,7 @@ static s32 vidWidth = 640;
 static s32 vidHeight = 480;
 static s32 vidFramebuffers = true;
 static s32 vidFullscreen = false;
+static s32 vidMaximize = false;
 static s32 vidVsync = 1;
 static s32 vidMSAA = 1;
 static s32 vidFramerateLimit = 0;
@@ -44,7 +45,7 @@ s32 videoInit(void)
 	gfx_framebuffers_enabled = (bool)vidFramebuffers;
 	gfx_msaa_level = vidMSAA;
 
-	gfx_init(wmAPI, renderingAPI, "PD", vidFullscreen, vidWidth, vidHeight, 100, 100);
+	gfx_init(wmAPI, renderingAPI, "PD", vidFullscreen, vidMaximize, vidWidth, vidHeight, 100, 100);
 
 	if (!wmAPI->set_swap_interval(vidVsync)) {
 		vidVsync = 0;
@@ -232,6 +233,7 @@ void videoFreeCachedTexture(const void *texptr)
 PD_CONSTRUCTOR static void videoConfigInit(void)
 {
 	configRegisterInt("Video.DefaultFullscreen", &vidFullscreen, 0, 1);
+	configRegisterInt("Video.DefaultMaximize", &vidMaximize, 0, 1);
 	configRegisterInt("Video.DefaultWidth", &vidWidth, 0, 32767);
 	configRegisterInt("Video.DefaultHeight", &vidHeight, 0, 32767);
 	configRegisterInt("Video.VSync", &vidVsync, -1, 10);


### PR DESCRIPTION
Since the main window is created at a specific dimension and position, I always have to click the maximize button after launching. 
Instead of doing that, I added a config value to create the window with the maximized flag.
(Screencast showing the window being created with and without the flag: https://youtu.be/bzQ9rrblL3M)

Not sure if this is a feature anyone else wants in addition to the existing full-screen option, but you can incorporate it if you'd like.
Although it's a quick hack. Not sure if extending the init function signatures like this (as opposed to maybe having some structure passed in with a bunch of settings like SDL flags, positions, etc.) is acceptable as-is.

If it does seem useful, I can try adding it to the in-game extended options menu near the full-screen one.
(Probably just call `SDL_MaximizeWindow`|`SDL_RestoreWindow` while toggling the value in the INI.)
However, it might make more sense to not have this option at all if SDL is capable of letting the OS save and restore the state of the window itself. (I'm not actually familiar with SDL.)