### PR TITLE
port: add maximize window option to extended menu

### DIFF
--- a/port/fast3d/gfx_sdl2.cpp
+++ b/port/fast3d/gfx_sdl2.cpp
@@ -36,6 +36,7 @@ static bool vsync_enabled = true;
 static int window_width = DESIRED_SCREEN_WIDTH;
 static int window_height = DESIRED_SCREEN_HEIGHT;
 static bool fullscreen_state;
+static bool maximized_state;
 static bool is_running = true;
 static void (*on_fullscreen_changed_callback)(bool is_now_fullscreen);
 
@@ -76,6 +77,18 @@ static void set_fullscreen(bool on, bool call_callback) {
     }
 }
 
+static void set_maximize_window(bool on) {
+	if (maximized_state == on) {
+		return;
+	}
+	maximized_state = on;
+	if (on) {
+		SDL_MaximizeWindow(wnd);
+	} else {
+		SDL_RestoreWindow (wnd);
+	}
+}
+
 static void gfx_sdl_get_active_window_refresh_rate(uint32_t* refresh_rate) {
     int display_in_use = SDL_GetWindowDisplayIndex(wnd);
 
@@ -110,10 +123,7 @@ static void gfx_sdl_init(const char* game_name, const char* gfx_api_name, bool s
         posY = 100;
     }
 
-    Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_OPENGL;
-    if (start_maximized) {
-        flags |= SDL_WINDOW_MAXIMIZED;
-    }
+    const Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_OPENGL;
 
     wnd = SDL_CreateWindow(title, posX, posY, window_width, window_height, flags);
     if (!wnd) {
@@ -185,6 +195,7 @@ static void gfx_sdl_init(const char* game_name, const char* gfx_api_name, bool s
     }
 #endif
 
+    set_maximize_window(start_maximized);
     set_fullscreen(start_in_fullscreen, false);
 }
 
@@ -198,6 +209,10 @@ static void gfx_sdl_set_fullscreen_changed_callback(void (*on_fullscreen_changed
 
 static void gfx_sdl_set_fullscreen(bool enable) {
     set_fullscreen(enable, true);
+}
+
+static void gfx_sdl_set_maximize_window(bool enable) {
+    set_maximize_window(enable);
 }
 
 static void gfx_sdl_set_cursor_visibility(bool visible) {
@@ -320,6 +335,7 @@ struct GfxWindowManagerAPI gfx_sdl = {
     gfx_sdl_close,
     gfx_sdl_set_fullscreen_changed_callback,
     gfx_sdl_set_fullscreen,
+    gfx_sdl_set_maximize_window,
     gfx_sdl_get_active_window_refresh_rate,
     gfx_sdl_set_cursor_visibility,
     gfx_sdl_get_dimensions,

--- a/port/fast3d/gfx_window_manager_api.h
+++ b/port/fast3d/gfx_window_manager_api.h
@@ -10,6 +10,7 @@ struct GfxWindowManagerAPI {
     void (*close)(void);
     void (*set_fullscreen_changed_callback)(void (*on_fullscreen_changed)(bool is_now_fullscreen));
     void (*set_fullscreen)(bool enable);
+    void (*set_maximize)(bool enable);
     void (*get_active_window_refresh_rate)(uint32_t* refresh_rate);
     void (*set_cursor_visibility)(bool visible);
     void (*get_dimensions)(uint32_t* width, uint32_t* height, int32_t* posX, int32_t* posY);

--- a/port/src/optionsmenu.c
+++ b/port/src/optionsmenu.c
@@ -652,6 +652,19 @@ static MenuItemHandlerResult menuhandlerFullScreen(s32 operation, struct menuite
 	return 0;
 }
 
+static MenuItemHandlerResult menuhandlerMaximizeWindow(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+	switch (operation) {
+	case MENUOP_GET:
+		return videoGetMaximizeWindow();
+	case MENUOP_SET:
+		videoSetMaximizeWindow(data->checkbox.value);
+		break;
+	}
+
+	return 0;
+}
+
 static MenuItemHandlerResult menuhandlerTexFilter(s32 operation, struct menuitem *item, union handlerdata *data)
 {
 	switch (operation) {
@@ -747,6 +760,14 @@ struct menuitem g_ExtendedVideoMenuItems[] = {
 		(uintptr_t)"Full Screen",
 		0,
 		menuhandlerFullScreen,
+	},
+	{
+		MENUITEMTYPE_CHECKBOX,
+		0,
+		MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"Maximize Window",
+		0,
+		menuhandlerMaximizeWindow,
 	},
 	{
 		MENUITEMTYPE_CHECKBOX,

--- a/port/src/video.c
+++ b/port/src/video.c
@@ -148,6 +148,11 @@ s32 videoGetFullscreen(void)
 	return vidFullscreen;
 }
 
+s32 videoGetMaximizeWindow(void)
+{
+	return vidMaximize;
+}
+
 f32 videoGetAspect(void)
 {
 	return gfx_current_dimensions.aspect_ratio;
@@ -174,6 +179,14 @@ void videoSetFullscreen(s32 fs)
 	if (fs != vidFullscreen) {
 		vidFullscreen = !!fs;
 		wmAPI->set_fullscreen(vidFullscreen);
+	}
+}
+
+void videoSetMaximizeWindow(s32 fs)
+{
+	if (fs != vidMaximize) {
+		vidMaximize = !!fs;
+		wmAPI->set_maximize(vidMaximize);
 	}
 }
 


### PR DESCRIPTION
Follow up to: https://github.com/fgsfdsfgs/perfect_dark/pull/308
This adds the maximize window setting to the extended video options menu.

~~Note that it also listens for `maximize` and `restore` window events to keep track of the window state, but this does not affect the settings toggle (the existing fullscreen option behaves this way too).
We only use this information to prevent redundantly calling the SDL window control functions when we receive a relevant event.
I.e. the window manager already manipulated the window, so we won't; we'll just note that it's been modified.
See: `set_maximize_window` and `gfx_sdl_handle_events`.~~

![Screenshot 2023-12-16 092915](https://github.com/fgsfdsfgs/perfect_dark/assets/13862850/1d13acc1-3af6-4d52-92f1-3ba35ddb2c76)

This also reverts the change to the flags initially made in #308, they remain const and we use SDL to maximize the window _after_ it's been created (rather than during creation). 