### PR TITLE
Add CI action to publish development builds to GitHub releases

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -65,4 +65,25 @@ jobs:
           name: pd-i686-linux
           path: bin/
           retention-days: 0
-      
+
+  publish-latest-build:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/port'
+    needs: [build-i686-windows, build-i686-linux]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: ci-artifacts
+      - name: Publish latest dev-build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir ci-release
+          pushd ci-artifacts
+          tar czf ../ci-release/pd-i686-linux.tar.gz pd-i686-linux
+          zip -r ../ci-release/pd-i686-windows.zip pd-i686-windows
+          popd
+          git tag --force ci-dev-build port
+          git push --force origin ci-dev-build
+          gh release upload --clobber ci-dev-build ci-release/*

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -26,7 +26,7 @@ jobs:
             mingw-w64-i686-SDL2
             mingw-w64-i686-zlib
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build pd.exe
         run: make -f Makefile.port -j
       - name: Prepare artifact for packaging
@@ -36,7 +36,7 @@ jobs:
           cp /mingw32/bin/{SDL2.dll,zlib1.dll,libgcc_s_dw2-1.dll,libwinpthread-1.dll} bin/
           touch bin/data/put_your_rom_here.txt
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pd-i686-windows
           path: bin/
@@ -51,7 +51,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install git gcc g++ gcc-multilib g++-multilib make libsdl2-dev zlib1g-dev libsdl2-dev:i386 zlib1g-dev:i386
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build pd.exe
         run: make -f Makefile.port TARGET_PLATFORM=i686-linux -j2
       - name: Prepare artifact for packaging
@@ -60,7 +60,7 @@ jobs:
           cp build/ntsc-final-port/pd.exe bin/pd
           touch bin/data/put_your_rom_here.txt
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pd-i686-linux
           path: bin/


### PR DESCRIPTION
This might make is easier for people to find the correct release.
It should also sidestep the fact that action artifacts have an eventual expiry / a retention time before GitHub deletes them.

**Prior to merging this commit:**
1) Check the fork's release assets
The release: https://github.com/djdv/perfect_dark/releases/tag/ci-dev-build
The run that created them: https://github.com/djdv/perfect_dark/actions/runs/7293469684
The current archive format and directory structure is:
(If desirable we could hoist the contents up a level to remove the `pd-i686-$OS` directory.)
```
.
|-- pd-i686-linux.tar.gz
|   `-- pd-i686-linux
|       |-- data
|       |   `-- put_your_rom_here.txt
|       `-- pd
`-- pd-i686-windows.zip
    `-- pd-i686-windows
        |-- SDL2.dll
        |-- data
        |   `-- put_your_rom_here.txt
        |-- libgcc_s_dw2-1.dll
        |-- libwinpthread-1.dll
        |-- pd.exe
        `-- zlib1.dll
```

2) Prepare the repo
```
git tag --force ci-dev-build port
git push origin ci-dev-build
```
The tag is arbitrary but we'll consider it reserved for use by the CI only.
(Of course we could pick another name too if you have a preference.)

3) Prepare a GitHub release:
https://github.com/fgsfdsfgs/releases/new
Use the `ci-dev-build` as the tag when creating a new release.
(Use whatever title, etc. Should probably tick the 'pre-release' box.)

4) Merge this PR
Afterwards, when the `port` branch updates and dependent jobs succeed, the CI will clobber both the `ci-dev-build` tag and release assets. This includes this commit itself so once it's merged the created release will have its assets populated.

---

Marked as draft so as to not accidentally merge before step 3 is done.
Once that's done you can flip it to "ready" and merge.