### PR TITLE
Add a crosshair size option

### DIFF
--- a/port/src/main.c
+++ b/port/src/main.c
@@ -171,5 +171,6 @@ PD_CONSTRUCTOR static void gameConfigInit(void)
 		configRegisterInt(strFmt("Game.Player%d.CrouchMode", i), &g_PlayerExtCfg[j].crouchmode, 0, CROUCHMODE_TOGGLE_ANALOG);
 		configRegisterInt(strFmt("Game.Player%d.ExtendedControls", i), &g_PlayerExtCfg[j].extcontrols, 0, 1);
 		configRegisterUInt(strFmt("Game.Player%d.CrosshairColour", i), &g_PlayerExtCfg[j].crosshaircolour, 0, 0xFFFFFFFF);
+		configRegisterUInt(strFmt("Game.Player%d.CrosshairSize", i), &g_PlayerExtCfg[j].crosshairsize, 0, 4);
 	}
 }

--- a/port/src/optionsmenu.c
+++ b/port/src/optionsmenu.c
@@ -945,6 +945,20 @@ static MenuItemHandlerResult menuhandlerCrosshairSway(s32 operation, struct menu
 	return 0;
 }
 
+static MenuItemHandlerResult menuhandlerCrosshairSize(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+	switch (operation) {
+	case MENUOP_GETSLIDER:
+		data->slider.value = g_PlayerExtCfg[g_ExtMenuPlayer].crosshairsize;
+		break;
+	case MENUOP_SET:
+		g_PlayerExtCfg[g_ExtMenuPlayer].crosshairsize = data->slider.value;
+		break;
+	}
+
+	return 0;
+}
+
 static MenuItemHandlerResult menuhandlerCrosshair_R(s32 operation, struct menuitem* item, union handlerdata* data)
 {
 	switch (operation) {
@@ -1119,6 +1133,14 @@ struct menuitem g_ExtendedGameMenuItems[] = {
 		(uintptr_t)"Crosshair Sway",
 		20,
 		menuhandlerCrosshairSway,
+	},
+	{
+		MENUITEMTYPE_SLIDER,
+		0,
+		MENUITEMFLAG_LITERAL_TEXT | MENUITEMFLAG_SLIDER_WIDE,
+		(uintptr_t)"Crosshair Size",
+		4,
+		menuhandlerCrosshairSize,
 	},
 	{
 		MENUITEMTYPE_SELECTABLE,

--- a/src/game/mplayer/mplayer.c
+++ b/src/game/mplayer/mplayer.c
@@ -126,6 +126,7 @@ struct mpweapon g_MpWeapons[NUM_MPWEAPONS] = {
 	.crouchmode = CROUCHMODE_TOGGLE_ANALOG, \
 	.extcontrols = true, \
 	.crosshaircolour = 0x00ff0028, \
+	.crosshairsize = 2, \
 }
 
 struct extplayerconfig g_PlayerExtCfg[MAX_LOCAL_PLAYERS] = { 

--- a/src/game/sight.c
+++ b/src/game/sight.c
@@ -1473,14 +1473,21 @@ Gfx *sightDrawTarget(Gfx *gdl)
 	gSPSetExtraGeometryModeEXT(gdl++, G_ASPECT_CENTER_EXT);
 #endif
 
-	gDPHudRectangle(gdl++, x + 2, y + 0, x + 6, y + 0);
-	gDPHudRectangle(gdl++, x + 2, y + 0, x + 4, y + 0);
-	gDPHudRectangle(gdl++, x - 6, y + 0, x - 2, y + 0);
-	gDPHudRectangle(gdl++, x - 4, y + 0, x - 2, y + 0);
-	gDPHudRectangle(gdl++, x + 0, y + 2, x + 0, y + 6);
-	gDPHudRectangle(gdl++, x + 0, y + 2, x + 0, y + 4);
-	gDPHudRectangle(gdl++, x + 0, y - 6, x + 0, y - 2);
-	gDPHudRectangle(gdl++, x + 0, y - 4, x + 0, y - 2);
+#define SIGHT_SCALE PLAYER_EXTCFG().crosshairsize
+
+	if (SIGHT_SCALE == 0) {
+		// Draw single rectangle to preserve intended opacity
+		gDPHudRectangle(gdl++, x, y, x, y);
+	} else {
+		gDPHudRectangle(gdl++, x + 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x + 3 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x + 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x + 2 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x - 3 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x - 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x - 2 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x - 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x + 0 * SIGHT_SCALE, y + 1 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y + 3 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x + 0 * SIGHT_SCALE, y + 1 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y + 2 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x + 0 * SIGHT_SCALE, y - 3 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y - 1 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x + 0 * SIGHT_SCALE, y - 2 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y - 1 * SIGHT_SCALE);
+	}
 
 #ifndef PLATFORM_N64
 	gSPClearExtraGeometryModeEXT(gdl++, G_ASPECT_CENTER_EXT);

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -6155,6 +6155,7 @@ struct extplayerconfig {
 	f32 crosshairsway;
 	s32 extcontrols;
 	u32 crosshaircolour;
+	u32 crosshairsize;
 };
 
 #endif


### PR DESCRIPTION
- Follow-up to https://github.com/fgsfdsfgs/perfect_dark/pull/300.

5 sizes are available (from 0 to 4), with 2 being the default vanilla-like value.

Size 0 is a dot with alpha adjusted to match the crosshair color settings.

I've tested a fresh configuration file and the crosshair size is correct.

## Preview

> [!NOTE]
>
> Alpha adjustments for dot crosshair weren't added when this video was recorded, so the dot crosshair appears more opaque than it would be now.

https://github.com/fgsfdsfgs/perfect_dark/assets/180032/222f3a98-eb78-4ac7-bb38-38813488650c
