### PR TITLE
Always use high detail weapon models

### DIFF
--- a/src/game/game_0b0fd0.c
+++ b/src/game/game_0b0fd0.c
@@ -398,9 +398,11 @@ u16 weaponGetFileNum(s32 weaponnum)
 	}
 
 	if (weapon) {
+#ifdef PLATFORM_N64
 		if (PLAYERCOUNT() >= 2) {
 			return weapon->lo_model;
 		}
+#endif
 
 		return weapon->hi_model;
 	}


### PR DESCRIPTION
PD uses low LOD models for multiplayer when playing with two players or more.

Single player:
![image](https://github.com/fgsfdsfgs/perfect_dark/assets/6194072/adfbc15f-3e8d-44b3-84dc-1c6a580d736d)

Multiplayer:
![image](https://github.com/fgsfdsfgs/perfect_dark/assets/6194072/72448b1f-5e01-4e55-942f-97dad2e48556)

You can see the lower polygon count on the CMP's handle. 

It makes no sense to keep using the low detail models in multiplayer now that we can play with other players online without splitscreen. This patch fixes that. 