### PR TITLE
[DRAFT] Manual Reloading and Autoswitch Settings

### DIFF
--- a/port/src/main.c
+++ b/port/src/main.c
@@ -163,6 +163,9 @@ PD_CONSTRUCTOR static void gameConfigInit(void)
 	configRegisterInt("Game.SkipIntro", &g_SkipIntro, 0, 1);
 	configRegisterInt("Game.DisableMpDeathMusic", &g_MusicDisableMpDeath, 0, 1);
 	configRegisterInt("Game.GEMuzzleFlashes", &g_BgunGeMuzzleFlashes, 0, 1);
+	configRegisterInt("Game.NoAutoSwitch", &g_BNoAutoSwitch, 0, 1);
+	configRegisterInt("Game.NoAutoReload", &g_BNoAutoReload, 0, 1);
+	configRegisterInt("Game.NoBackpackReload", &g_BNoBackpackReload, 0, 1);
 	for (s32 j = 0; j < MAX_PLAYERS; ++j) {
 		const s32 i = j + 1;
 		configRegisterFloat(strFmt("Game.Player%d.FovY", i), &g_PlayerExtCfg[j].fovy, 5.f, 175.f);

--- a/port/src/optionsmenu.c
+++ b/port/src/optionsmenu.c
@@ -19,6 +19,45 @@ static struct menudialogdef *g_ExtNextDialog = NULL;
 static s32 g_BindIndex = 0;
 static u32 g_BindContKey = 0;
 
+static MenuItemHandlerResult menuhandlerNoAutoSwitch(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+	switch (operation) {
+	case MENUOP_GET:
+		return g_BNoAutoSwitch;
+	case MENUOP_SET:
+		g_BNoAutoSwitch = data->checkbox.value;
+		break;
+	}
+
+	return 0;
+}
+
+static MenuItemHandlerResult menuhandlerNoAutoReload(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+	switch (operation) {
+	case MENUOP_GET:
+		return g_BNoAutoReload;
+	case MENUOP_SET:
+		g_BNoAutoReload = data->checkbox.value;
+		break;
+	}
+
+	return 0;
+}
+
+static MenuItemHandlerResult menuhandlerNoBackpackReload(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+	switch (operation) {
+	case MENUOP_GET:
+		return g_BNoBackpackReload;
+	case MENUOP_SET:
+		g_BNoBackpackReload = data->checkbox.value;
+		break;
+	}
+
+	return 0;
+}
+
 static MenuItemHandlerResult menuhandlerSelectPlayer(s32 operation, struct menuitem *item, union handlerdata *data);
 
 struct menuitem g_ExtendedSelectPlayerMenuItems[] = {
@@ -1125,6 +1164,30 @@ struct menuitem g_ExtendedGameMenuItems[] = {
 		(uintptr_t)"Crouch Mode",
 		0,
 		menuhandlerCrouchMode,
+	},
+	{
+		MENUITEMTYPE_CHECKBOX,
+		0,
+		MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"No Auto Weapon Switch",
+		20,
+		menuhandlerNoAutoSwitch,
+	},
+	{
+		MENUITEMTYPE_CHECKBOX,
+		0,
+		MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"No Auto Reloading",
+		20,
+		menuhandlerNoAutoReload,
+	},
+	{
+		MENUITEMTYPE_CHECKBOX,
+		0,
+		MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"No Backpack Reloads",
+		20,
+		menuhandlerNoBackpackReload,
 	},
 	{
 		MENUITEMTYPE_SLIDER,

--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -1213,7 +1213,6 @@ s32 bgunTickIncIdle(struct handweaponinfo *info, s32 handnum, struct hand *hand,
 	s32 next;
 	struct hand *lhand;
 	struct weaponfunc *func;
-	bool reloadCheck = false;
 
 	hand->lastdirvalid = false;
 	hand->burstbullets = 0;
@@ -1319,8 +1318,8 @@ s32 bgunTickIncIdle(struct handweaponinfo *info, s32 handnum, struct hand *hand,
 				if (bgunSetState(handnum, HANDSTATE_ATTACKEMPTY)) {
 					return lvupdate;
 				}
-			} else if (g_BNoAutoReload && hand->modenext == HANDMODE_NONE) {
-				reloadCheck = true;
+			} else if (g_BNoAutoReload && hand->modenext != HANDMODE_RELOAD) {
+				hand->modenext = HANDMODE_EMPTY;
 			} else {
 				hand->count60 = 0;
 				hand->count = 0;
@@ -1350,7 +1349,7 @@ s32 bgunTickIncIdle(struct handweaponinfo *info, s32 handnum, struct hand *hand,
 
 			// Not attacking, but the player may have attempted
 			// to change guns or reload while firing
-			if (hand->modenext != HANDMODE_NONE || reloadCheck) {
+			if (hand->modenext != HANDMODE_NONE) {
 				next = hand->modenext;
 
 				hand->mode = hand->modenext;
@@ -6052,7 +6051,7 @@ void bgunReloadIfPossible(s32 handnum)
 	struct player *player = g_Vars.currentplayer;
 
 	if (bgunGetAmmoTypeForWeapon(bgunGetWeaponNum(handnum), FUNC_PRIMARY)
-			&& player->hands[handnum].modenext == HANDMODE_NONE) {
+			&& (player->hands[handnum].modenext == HANDMODE_NONE || player->hands[handnum].modenext == HANDMODE_EMPTY)) {
 		player->hands[handnum].modenext = HANDMODE_RELOAD;
 	}
 }

--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -1203,6 +1203,18 @@ bool bgun0f099188(struct hand *hand, s32 gunfunc)
 	return bgun0f0990b0(func, weapon);
 }
 
+//Play a click sound when we have no ammo
+bool dryfire(struct handweaponinfo *info, struct hand *hand, s32 handnum)
+{
+	if (info->weaponnum != WEAPON_NONE) {
+		hand->unk0cc8_01 = false;
+
+		if (bgunSetState(handnum, HANDSTATE_ATTACKEMPTY))
+			return true;
+	}
+	return false;
+}
+
 s32 bgunTickIncIdle(struct handweaponinfo *info, s32 handnum, struct hand *hand, s32 lvupdate)
 {
 	bool usesec;
@@ -1310,14 +1322,15 @@ s32 bgunTickIncIdle(struct handweaponinfo *info, s32 handnum, struct hand *hand,
 					}
 				}
 			}
+			
+			// Clip is empty and we have no reserve ammo
+			if (hand->triggeron && dryfire(info, hand, handnum)) {
+				return lvupdate;
+			}
 		} else if (sp34 == 0) {
 			// Clip is empty
-			if (hand->triggeron && info->weaponnum != WEAPON_NONE) {
-				hand->unk0cc8_01 = false;
-
-				if (bgunSetState(handnum, HANDSTATE_ATTACKEMPTY)) {
-					return lvupdate;
-				}
+			if (hand->triggeron && dryfire(info, hand, handnum)) {
+				return lvupdate;
 			} else if (g_BNoAutoReload && hand->modenext != HANDMODE_RELOAD) {
 				hand->modenext = HANDMODE_EMPTY;
 			} else {

--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -163,6 +163,12 @@ struct fireslot g_Fireslots[20];
 u32 fill2[1];
 #endif
 
+#ifndef PLATFORM_N64
+bool g_BNoAutoSwitch = false;
+bool g_BNoAutoReload = false;
+bool g_BNoBackpackReload = false;
+#endif
+
 Lights1 var80070090 = gdSPDefLights1(0x96, 0x96, 0x96, 0xff, 0xff, 0xff, 0xb2, 0x4d, 0x2e);
 
 u32 g_BgunGunMemBaseSizeDefault = 150 * 1024;
@@ -1117,6 +1123,7 @@ void bgun0f098df8(s32 weaponfunc, struct handweaponinfo *info, struct hand *hand
 	}
 }
 
+//TODO: Control this with a backpack reload setting
 void bgun0f098f8c(struct handweaponinfo *info, struct hand *hand)
 {
 	s32 i;
@@ -1315,7 +1322,7 @@ s32 bgunTickIncIdle(struct handweaponinfo *info, s32 handnum, struct hand *hand,
 				hand->count60 = 0;
 				hand->count = 0;
 
-				if (bgunSetState(handnum, HANDSTATE_RELOAD)) {
+				if (g_BNoAutoReload || bgunSetState(handnum, HANDSTATE_RELOAD)) {
 					hand->modenext = HANDMODE_NONE;
 					return lvupdate;
 				}
@@ -5869,7 +5876,7 @@ void bgunAutoSwitchWeapon(void)
 	s32 curweaponnum = g_Vars.currentplayer->gunctrl.weaponnum;
 	bool wantammo = false;
 
-	if (g_Vars.tickmode == TICKMODE_CUTSCENE) {
+	if (g_Vars.tickmode == TICKMODE_CUTSCENE || g_BNoAutoSwitch) {
 		return;
 	}
 

--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -1213,6 +1213,7 @@ s32 bgunTickIncIdle(struct handweaponinfo *info, s32 handnum, struct hand *hand,
 	s32 next;
 	struct hand *lhand;
 	struct weaponfunc *func;
+	bool reloadCheck = false;
 
 	hand->lastdirvalid = false;
 	hand->burstbullets = 0;
@@ -1318,11 +1319,13 @@ s32 bgunTickIncIdle(struct handweaponinfo *info, s32 handnum, struct hand *hand,
 				if (bgunSetState(handnum, HANDSTATE_ATTACKEMPTY)) {
 					return lvupdate;
 				}
+			} else if (g_BNoAutoReload && hand->modenext == HANDMODE_NONE) {
+				reloadCheck = true;
 			} else {
 				hand->count60 = 0;
 				hand->count = 0;
 
-				if (g_BNoAutoReload || bgunSetState(handnum, HANDSTATE_RELOAD)) {
+				if (bgunSetState(handnum, HANDSTATE_RELOAD)) {
 					hand->modenext = HANDMODE_NONE;
 					return lvupdate;
 				}
@@ -1347,7 +1350,7 @@ s32 bgunTickIncIdle(struct handweaponinfo *info, s32 handnum, struct hand *hand,
 
 			// Not attacking, but the player may have attempted
 			// to change guns or reload while firing
-			if (hand->modenext != HANDMODE_NONE) {
+			if (hand->modenext != HANDMODE_NONE || reloadCheck) {
 				next = hand->modenext;
 
 				hand->mode = hand->modenext;

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -1278,6 +1278,7 @@
 #define HANDMODE_11     11
 #define HANDMODE_12     12
 #define HANDMODE_13     13
+#define HANDMODE_EMPTY 	14
 
 #define HANDSTATE_IDLE        0
 #define HANDSTATE_RELOAD      1

--- a/src/include/data.h
+++ b/src/include/data.h
@@ -550,6 +550,9 @@ extern s32 g_TickRateDiv;
 extern s32 g_MusicDisableMpDeath;
 extern s32 g_BgunGeMuzzleFlashes;
 extern s32 g_FileAutoSelect;
+extern bool g_BNoAutoSwitch;
+extern bool g_BNoAutoReload;
+extern bool g_BNoBackpackReload;
 
 #define PLAYER_EXTCFG() g_PlayerExtCfg[g_Vars.currentplayerstats->mpindex & 3]
 #define PLAYER_DEFAULT_FOV (PLAYER_EXTCFG().fovy)


### PR DESCRIPTION
This is designed to address #363.

This is my first major open source contribution, please be gentle.

This currently adds 3 new gameplay options:
![image](https://github.com/fgsfdsfgs/perfect_dark/assets/31608726/35df949f-3738-4334-9593-fa371ec4f354)

1. No Auto Weapon Switch. This stops automatically switching to a different weapon when you completely run out of ammo with a given weapon.
2. No Auto Reloading. This prevents the game from automatically reloading your weapon once your current clip is empty.
3. No Backpack Reloading. This prevents the game from automatically reloading weapons that are in your backpack. They should remember their existing ammo count.

Current Status:
1. No Auto Weapon Switch. **Completed**
2. No Auto Reloading. **Completed**.
3. No Backpack Reloading. **Not Started**. I don't know how to realistically approach this. I know the Shotgun etc store their current ammo value, but I don't know how to extend it to every weapon or make it generic. I don't even know if that would be viable to do. I can remove this part of the feature request if it turns out to either be too difficult, or out of scope for the project. 