### PR TITLE
Add an option to color crosshair according to player health + shield

### DIFF
--- a/port/src/main.c
+++ b/port/src/main.c
@@ -176,5 +176,6 @@ PD_CONSTRUCTOR static void gameConfigInit(void)
 		configRegisterInt(strFmt("Game.Player%d.ExtendedControls", i), &g_PlayerExtCfg[j].extcontrols, 0, 1);
 		configRegisterUInt(strFmt("Game.Player%d.CrosshairColour", i), &g_PlayerExtCfg[j].crosshaircolour, 0, 0xFFFFFFFF);
 		configRegisterUInt(strFmt("Game.Player%d.CrosshairSize", i), &g_PlayerExtCfg[j].crosshairsize, 0, 4);
+		configRegisterInt(strFmt("Game.Player%d.CrosshairHealth", i), &g_PlayerExtCfg[j].crosshairhealth, 0, CROSSHAIR_HEALTH_ON_WHITE);
 	}
 }

--- a/port/src/optionsmenu.c
+++ b/port/src/optionsmenu.c
@@ -1040,6 +1040,30 @@ static MenuItemHandlerResult menuhandlerCrosshairSize(s32 operation, struct menu
 	return 0;
 }
 
+static MenuItemHandlerResult menuhandlerCrosshairHealth(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+	static const char *opts[] = {
+		"Off",
+		"On (Green)",
+		"On (White)"
+	};
+
+	switch (operation) {
+	case MENUOP_GETOPTIONCOUNT:
+		data->dropdown.value = ARRAYCOUNT(opts);
+		break;
+	case MENUOP_GETOPTIONTEXT:
+		return (intptr_t)opts[data->dropdown.value];
+	case MENUOP_SET:
+		g_PlayerExtCfg[g_ExtMenuPlayer].crosshairhealth = data->dropdown.value;
+		break;
+	case MENUOP_GETSELECTEDINDEX:
+		data->dropdown.value = g_PlayerExtCfg[g_ExtMenuPlayer].crosshairhealth;
+	}
+
+	return 0;
+}
+
 struct menuitem g_ExtendedGameCrosshairColourMenuItems[] = {
 	{
 		MENUITEMTYPE_SLIDER,
@@ -1157,6 +1181,14 @@ struct menuitem g_ExtendedGameMenuItems[] = {
 		(uintptr_t)"Crosshair Colour\n",
 		0,
 		(void*)&g_ExtendedGameCrosshairColourMenuDialog,
+	},
+	{
+		MENUITEMTYPE_DROPDOWN,
+		0,
+		MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"Crosshair Colour by Health",
+		0,
+		menuhandlerCrosshairHealth,
 	},
 	{
 		MENUITEMTYPE_SEPARATOR,

--- a/src/game/mplayer/mplayer.c
+++ b/src/game/mplayer/mplayer.c
@@ -124,6 +124,7 @@ struct mpweapon g_MpWeapons[NUM_MPWEAPONS] = {
 	.extcontrols = true, \
 	.crosshaircolour = 0x00ff0028, \
 	.crosshairsize = 2, \
+	.crosshairhealth = CROSSHAIR_HEALTH_OFF, \
 }
 
 struct extplayerconfig g_PlayerExtCfg[MAX_PLAYERS] = { 

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -4718,6 +4718,10 @@ enum weaponnum {
 #define CROUCHMODE_TOGGLE 2 // press the crouch buttons to toggle stance
 #define CROUCHMODE_TOGGLE_ANALOG (CROUCHMODE_ANALOG | CROUCHMODE_TOGGLE)
 
+#define CROSSHAIR_HEALTH_OFF 0
+#define CROSSHAIR_HEALTH_ON_GREEN 1
+#define CROSSHAIR_HEALTH_ON_WHITE 2
+
 #endif
 
 #endif

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -6141,6 +6141,7 @@ struct extplayerconfig {
 	s32 extcontrols;
 	u32 crosshaircolour;
 	u32 crosshairsize;
+	s32 crosshairhealth;
 };
 
 #endif


### PR DESCRIPTION
- Follow-up to https://github.com/fgsfdsfgs/perfect_dark/pull/332.

This is useful to know your health + shield at any time without opening the pause menu.

Shield is taken into account and is added to health for the calculation, as the vast majority of damage types are fully blocked by a shield.

3 modes are available:

- Off (default)
- On (Green): Goes through a red-yellow-green-cyan gradient, closer to vanilla.
- On (White): Goes through a red-yellow-white-green gradient, closer to games like Xonotic.

When set to either of the On modes, the crosshair color setting is ignored but the crosshair alpha setting is still used.

![image](https://github.com/fgsfdsfgs/perfect_dark/assets/180032/6578b1bf-ab80-4dda-997c-d2921839ca60)

## Preview

*I have full health + shield at the beginning of both videos.*

### On (Green)

https://github.com/fgsfdsfgs/perfect_dark/assets/180032/f2399de1-7b2e-40b7-bb4e-d2132c036221

### On (White)

https://github.com/fgsfdsfgs/perfect_dark/assets/180032/9d9d37dd-638a-4d76-8e15-cd08ec733d6c
