### PR TITLE
Always hide crosshair when dead

### DIFF
--- a/src/game/sight.c
+++ b/src/game/sight.c
@@ -1536,6 +1536,13 @@ Gfx *sightDraw(Gfx *gdl, bool sighton, s32 sight)
 		sight = SIGHT_DEFAULT;
 	}
 
+#ifndef PLATFORM_N64
+	if (g_Vars.currentplayer->bondhealth <= 0.0f) {
+		// Hide crosshair during death animation
+		sight = SIGHT_NONE;
+	}
+#endif
+
 	sightTick(sighton);
 
 	switch (sight) {


### PR DESCRIPTION
Previously, the crosshair would show up during the death animation if Always Show Target is enabled or if aiming just before dying.

## Preview

### Before

https://github.com/fgsfdsfgs/perfect_dark/assets/180032/22623605-b990-42e1-9b3c-375841f178b1

### After

https://github.com/fgsfdsfgs/perfect_dark/assets/180032/27c088ba-0817-4212-a50e-6cdf4707b301
