### PR TITLE
Add port-net/netplay build links to default README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ though you might have to install some additional libraries.
 
 Latest [automatic builds](https://github.com/fgsfdsfgs/perfect_dark/actions) for supported platforms:
 * [i686-windows](https://nightly.link/fgsfdsfgs/perfect_dark/workflows/c-cpp/port/pd-i686-windows.zip)
+* [i686-windows (port-net/netplay)](https://nightly.link/fgsfdsfgs/perfect_dark/workflows/c-cpp/port-net/pd-i686-windows.zip)
 * [i686-linux](https://nightly.link/fgsfdsfgs/perfect_dark/workflows/c-cpp/port/pd-i686-linux.zip)
+* [i686-linux (port-net/netplay)](https://nightly.link/fgsfdsfgs/perfect_dark/workflows/c-cpp/port-net/pd-i686-linux.zip)
 
 ## Running
 


### PR DESCRIPTION
Some people are having trouble downloading/playing the right netplay version because of Github's main README always defaulting to master's README.MD, which links direct to _port_ branch, not _port-net_.
This includes _netplay links_ in the master branch README as well.