### PR TITLE
port-net: Extend counter-op mode to 4 players

### DIFF
--- a/port/src/pdmain.c
+++ b/port/src/pdmain.c
@@ -465,7 +465,13 @@ void mainLoop(void)
 		}
 
 		if (g_Vars.coopplayernum >= 0 || g_Vars.antiplayernum >= 0) {
+#ifdef PLATFORM_N64
 			g_MpSetup.chrslots = 0x03;
+#else
+			if (getNumPlayers() <= 2) {
+				g_MpSetup.chrslots = 0x03;
+			}
+#endif
 			mpReset();
 		} else if (g_Vars.perfectbuddynum) {
 			mpReset();

--- a/port/src/pdmain.c
+++ b/port/src/pdmain.c
@@ -468,7 +468,9 @@ void mainLoop(void)
 #ifdef PLATFORM_N64
 			g_MpSetup.chrslots = 0x03;
 #else
-			if (getNumPlayers() <= 2) {
+			if (g_Vars.antiplayernum < 0) {
+				// Counter-Operative now uses a different approach which allows more than 2 players.
+				// Co-Operative, on the other hand, is currently limited to 2 players.
 				g_MpSetup.chrslots = 0x03;
 			}
 #endif

--- a/src/game/bondwalk.c
+++ b/src/game/bondwalk.c
@@ -475,7 +475,11 @@ bool bwalkCalculateNewPositionWithPush(struct coord *delta, f32 rotateamount, bo
 					}
 				} else if (chr->chrflags & CHRCFLAG_PUSHABLE) {
 					if (g_Vars.antiplayernum < 0
+#ifdef PLATFORM_N64
 							|| g_Vars.currentplayer != g_Vars.anti
+#else
+							|| g_Vars.currentplayer == g_Vars.bond
+#endif
 							|| (chr->hidden & CHRHFLAG_ANTINONINTERACTABLE) == 0) {
 						canpush = true;
 					}
@@ -809,7 +813,11 @@ void bwalkUpdateVertical(void)
 	// Maybe reset counter-op's radius - not sure why
 	// Maybe it gets set to 0 when they die?
 	if (g_Vars.antiplayernum >= 0
+#ifdef PLATFORM_N64
 			&& g_Vars.currentplayer == g_Vars.anti
+#else
+			&& g_Vars.currentplayer != g_Vars.bond
+#endif
 			&& g_Vars.currentplayer->bond2.radius != 30
 			&& cdTestVolume(&g_Vars.currentplayer->prop->pos, 30, g_Vars.currentplayer->prop->rooms, CDTYPE_ALL, CHECKVERTICAL_YES, ymax - g_Vars.currentplayer->prop->pos.y, ymin - g_Vars.currentplayer->prop->pos.y)) {
 		g_Vars.currentplayer->prop->chr->radius = 30;

--- a/src/game/bondwalk.c
+++ b/src/game/bondwalk.c
@@ -475,11 +475,7 @@ bool bwalkCalculateNewPositionWithPush(struct coord *delta, f32 rotateamount, bo
 					}
 				} else if (chr->chrflags & CHRCFLAG_PUSHABLE) {
 					if (g_Vars.antiplayernum < 0
-#ifdef PLATFORM_N64
-							|| g_Vars.currentplayer != g_Vars.anti
-#else
-							|| g_Vars.currentplayer == g_Vars.bond
-#endif
+							|| PLAYER_IS_NOT_ANTI(g_Vars.currentplayer)
 							|| (chr->hidden & CHRHFLAG_ANTINONINTERACTABLE) == 0) {
 						canpush = true;
 					}
@@ -813,11 +809,7 @@ void bwalkUpdateVertical(void)
 	// Maybe reset counter-op's radius - not sure why
 	// Maybe it gets set to 0 when they die?
 	if (g_Vars.antiplayernum >= 0
-#ifdef PLATFORM_N64
-			&& g_Vars.currentplayer == g_Vars.anti
-#else
-			&& g_Vars.currentplayer != g_Vars.bond
-#endif
+			&& PLAYER_IS_ANTI(g_Vars.currentplayer)
 			&& g_Vars.currentplayer->bond2.radius != 30
 			&& cdTestVolume(&g_Vars.currentplayer->prop->pos, 30, g_Vars.currentplayer->prop->rooms, CDTYPE_ALL, CHECKVERTICAL_YES, ymax - g_Vars.currentplayer->prop->pos.y, ymin - g_Vars.currentplayer->prop->pos.y)) {
 		g_Vars.currentplayer->prop->chr->radius = 30;

--- a/src/game/chr.c
+++ b/src/game/chr.c
@@ -4662,7 +4662,7 @@ void chrHit(struct shotdata *shotdata, struct hit *hit)
 				hit->model, hit->hitthing.unk28 / 2, sp90);
 
 		if (g_Vars.antiplayernum >= 0
-				&& g_Vars.currentplayer == g_Vars.anti
+				&& PLAYER_IS_ANTI(g_Vars.currentplayer)
 				&& (chr->hidden & CHRHFLAG_ANTINONINTERACTABLE)) {
 			return;
 		}

--- a/src/game/chraction.c
+++ b/src/game/chraction.c
@@ -4351,14 +4351,7 @@ void chrDamage(struct chrdata *chr, f32 damage, struct coord *vector, struct gse
 	// Don't damage if attacker was anti and chr is non-interactable by anti
 	if (g_Vars.antiplayernum >= 0
 			&& aprop
-
-#ifdef PLATFORM_N64
-			&& aprop == g_Vars.anti->prop
-#else
-			&& aprop->type == PROPTYPE_PLAYER
-			&& aprop != g_Vars.bond->prop
-#endif
-
+			&& PROP_IS_FOR_ANTI_PLAYER(aprop)
 			&& (chr->hidden & CHRHFLAG_ANTINONINTERACTABLE)) {
 		return;
 	}
@@ -4498,13 +4491,7 @@ void chrDamage(struct chrdata *chr, f32 damage, struct coord *vector, struct gse
 
 		// Anti shooting other enemies is lethal
 		if (aprop
-#ifdef PLATFORM_N64
-				&& aprop == g_Vars.anti->prop
-#else
-				&& aprop->type == PROPTYPE_PLAYER
-				&& aprop != g_Vars.bond->prop
-#endif
-
+				&& PROP_IS_FOR_ANTI_PLAYER(aprop)
 				&& vprop != g_Vars.bond->prop) {
 			damage *= 100;
 		}
@@ -8336,14 +8323,7 @@ void chrAlertOthersOfInjury(struct chrdata *chr, bool dying)
 	s32 numinrange = 0;
 	s32 numchrs = chrsGetNumSlots();
 
-	if (g_Vars.antiplayernum >= 0
-#ifdef PLATFORM_N64
-			&& chr->prop == g_Vars.anti->prop
-#else
-			&& chr->prop->type == PROPTYPE_PLAYER
-			&& chr->prop != g_Vars.bond->prop
-#endif
-			) {
+	if (g_Vars.antiplayernum >= 0 && PROP_IS_FOR_ANTI_PLAYER(chr->prop)) {
 		return;
 	}
 
@@ -13578,11 +13558,7 @@ void chraTickBg(void)
 
 				if (targetprop && (targetprop->type == PROPTYPE_CHR || targetprop->type == PROPTYPE_PLAYER)) {
 					if ((targetprop->type == PROPTYPE_PLAYER
-#ifdef PLATFORM_N64
-								&& !(g_Vars.antiplayernum >= 0 && g_Vars.anti && g_Vars.anti->prop == targetprop)
-#else
-								&& !(g_Vars.antiplayernum >= 0 && g_Vars.bond && g_Vars.bond->prop != targetprop)
-#endif
+								&& !(g_Vars.antiplayernum >= 0 && g_Vars.anti && PROP_IS_FOR_ANTI_PLAYER(targetprop))
 								&& chrCompareTeams(chr, targetprop->chr, COMPARE_ENEMIES))
 							|| CHRRACE(targetprop->chr) == RACE_EYESPY) {
 						s32 time60;

--- a/src/game/chraction.c
+++ b/src/game/chraction.c
@@ -4351,7 +4351,14 @@ void chrDamage(struct chrdata *chr, f32 damage, struct coord *vector, struct gse
 	// Don't damage if attacker was anti and chr is non-interactable by anti
 	if (g_Vars.antiplayernum >= 0
 			&& aprop
+
+#ifdef PLATFORM_N64
 			&& aprop == g_Vars.anti->prop
+#else
+			&& aprop->type == PROPTYPE_PLAYER
+			&& aprop != g_Vars.bond->prop
+#endif
+
 			&& (chr->hidden & CHRHFLAG_ANTINONINTERACTABLE)) {
 		return;
 	}
@@ -4490,7 +4497,15 @@ void chrDamage(struct chrdata *chr, f32 damage, struct coord *vector, struct gse
 		}
 
 		// Anti shooting other enemies is lethal
-		if (aprop && aprop == g_Vars.anti->prop && vprop != g_Vars.bond->prop) {
+		if (aprop
+#ifdef PLATFORM_N64
+				&& aprop == g_Vars.anti->prop
+#else
+				&& aprop->type == PROPTYPE_PLAYER
+				&& aprop != g_Vars.bond->prop
+#endif
+
+				&& vprop != g_Vars.bond->prop) {
 			damage *= 100;
 		}
 	} else {
@@ -8321,7 +8336,14 @@ void chrAlertOthersOfInjury(struct chrdata *chr, bool dying)
 	s32 numinrange = 0;
 	s32 numchrs = chrsGetNumSlots();
 
-	if (g_Vars.antiplayernum >= 0 && chr->prop == g_Vars.anti->prop) {
+	if (g_Vars.antiplayernum >= 0
+#ifdef PLATFORM_N64
+			&& chr->prop == g_Vars.anti->prop
+#else
+			&& chr->prop->type == PROPTYPE_PLAYER
+			&& chr->prop != g_Vars.bond->prop
+#endif
+			) {
 		return;
 	}
 
@@ -13556,7 +13578,11 @@ void chraTickBg(void)
 
 				if (targetprop && (targetprop->type == PROPTYPE_CHR || targetprop->type == PROPTYPE_PLAYER)) {
 					if ((targetprop->type == PROPTYPE_PLAYER
+#ifdef PLATFORM_N64
 								&& !(g_Vars.antiplayernum >= 0 && g_Vars.anti && g_Vars.anti->prop == targetprop)
+#else
+								&& !(g_Vars.antiplayernum >= 0 && g_Vars.bond && g_Vars.bond->prop != targetprop)
+#endif
 								&& chrCompareTeams(chr, targetprop->chr, COMPARE_ENEMIES))
 							|| CHRRACE(targetprop->chr) == RACE_EYESPY) {
 						s32 time60;

--- a/src/game/chraicommands.c
+++ b/src/game/chraicommands.c
@@ -52,6 +52,10 @@
 #include "data.h"
 #include "types.h"
 
+#ifndef PLATFORM_N64
+#include "game/mplayer/mplayer.h"
+#endif
+
 /**
  * @cmd 0000
  */
@@ -6035,11 +6039,35 @@ bool aiSetChrPresetToChrNearPad(void)
 bool aiChrSetTeam(void)
 {
 	u8 *cmd = g_Vars.ailist + g_Vars.aioffset;
+#ifdef PLATFORM_N64
 	struct chrdata *chr = chrFindById(g_Vars.chrdata, cmd[2]);
 
 	if (chr) {
 		chr->team = cmd[3];
 	}
+#else
+	u32 playernum;
+	if (cmd[2] == CHR_ANTI && g_Vars.antiplayernum >= 0) {
+		// There can be multiple counter-op players, so set this for all.
+		for (playernum = 0; playernum < PLAYERCOUNT(); playernum++) {
+			struct player *player = g_Vars.players[playernum];
+
+			if (player && PLAYER_IS_ANTI(player)) {
+				struct chrdata *chr = player->prop->chr;
+
+				if (chr) {
+					chr->team = cmd[3];
+				}
+			}
+		}
+	} else {
+		struct chrdata *chr = chrFindById(g_Vars.chrdata, cmd[2]);
+
+		if (chr) {
+			chr->team = cmd[3];
+		}
+	}
+#endif
 
 	g_Vars.aioffset += 4;
 

--- a/src/game/endscreen.c
+++ b/src/game/endscreen.c
@@ -1700,14 +1700,22 @@ void endscreenPushCoop(void)
 #endif
 	{
 		// Failed or aborted
-		if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL) {
+		if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
+#ifndef PLATFORM_N64
+			|| PLAYERCOUNT() >= 3
+#endif
+		) {
 			menuPushRootDialog(&g_2PMissionEndscreenFailedVMenuDialog, MENUROOT_MPENDSCREEN);
 		} else {
 			menuPushRootDialog(&g_2PMissionEndscreenFailedHMenuDialog, MENUROOT_MPENDSCREEN);
 		}
 	} else {
 		// Completed
-		if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL) {
+		if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
+#ifndef PLATFORM_N64
+			|| PLAYERCOUNT() >= 3
+#endif
+		) {
 			menuPushRootDialog(&g_2PMissionEndscreenCompletedVMenuDialog, MENUROOT_MPENDSCREEN);
 		} else {
 			menuPushRootDialog(&g_2PMissionEndscreenCompletedHMenuDialog, MENUROOT_MPENDSCREEN);
@@ -1793,14 +1801,22 @@ void endscreenPushAnti(void)
 #endif
 		{
 			// Bond - failed or aborted
-			if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL) {
+			if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
+#ifndef PLATFORM_N64
+				|| PLAYERCOUNT() >= 3
+#endif
+			) {
 				menuPushRootDialog(&g_2PMissionEndscreenFailedVMenuDialog, MENUROOT_MPENDSCREEN);
 			} else {
 				menuPushRootDialog(&g_2PMissionEndscreenFailedHMenuDialog, MENUROOT_MPENDSCREEN);
 			}
 		} else {
 			// Bond - completed
-			if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL) {
+			if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
+#ifndef PLATFORM_N64
+				|| PLAYERCOUNT() >= 3
+#endif
+			) {
 				menuPushRootDialog(&g_2PMissionEndscreenCompletedVMenuDialog, MENUROOT_MPENDSCREEN);
 			} else {
 				menuPushRootDialog(&g_2PMissionEndscreenCompletedHMenuDialog, MENUROOT_MPENDSCREEN);
@@ -1816,14 +1832,22 @@ void endscreenPushAnti(void)
 #endif
 		{
 			// Anti - completed
-			if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL) {
+			if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
+#ifndef PLATFORM_N64
+				|| PLAYERCOUNT() >= 3
+#endif
+			) {
 				menuPushRootDialog(&g_2PMissionEndscreenCompletedVMenuDialog, MENUROOT_MPENDSCREEN);
 			} else {
 				menuPushRootDialog(&g_2PMissionEndscreenCompletedHMenuDialog, MENUROOT_MPENDSCREEN);
 			}
 		} else {
 			// Anti - failed or aborted
-			if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL) {
+			if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
+#ifndef PLATFORM_N64
+				|| PLAYERCOUNT() >= 3
+#endif
+			) {
 				menuPushRootDialog(&g_2PMissionEndscreenFailedVMenuDialog, MENUROOT_MPENDSCREEN);
 			} else {
 				menuPushRootDialog(&g_2PMissionEndscreenFailedHMenuDialog, MENUROOT_MPENDSCREEN);

--- a/src/game/endscreen.c
+++ b/src/game/endscreen.c
@@ -1702,7 +1702,7 @@ void endscreenPushCoop(void)
 		// Failed or aborted
 		if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
 #ifndef PLATFORM_N64
-			|| PLAYERCOUNT() >= 3
+			|| LOCALPLAYERCOUNT() >= 3
 #endif
 		) {
 			menuPushRootDialog(&g_2PMissionEndscreenFailedVMenuDialog, MENUROOT_MPENDSCREEN);
@@ -1713,7 +1713,7 @@ void endscreenPushCoop(void)
 		// Completed
 		if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
 #ifndef PLATFORM_N64
-			|| PLAYERCOUNT() >= 3
+			|| LOCALPLAYERCOUNT() >= 3
 #endif
 		) {
 			menuPushRootDialog(&g_2PMissionEndscreenCompletedVMenuDialog, MENUROOT_MPENDSCREEN);
@@ -1803,7 +1803,7 @@ void endscreenPushAnti(void)
 			// Bond - failed or aborted
 			if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
 #ifndef PLATFORM_N64
-				|| PLAYERCOUNT() >= 3
+				|| LOCALPLAYERCOUNT() >= 3
 #endif
 			) {
 				menuPushRootDialog(&g_2PMissionEndscreenFailedVMenuDialog, MENUROOT_MPENDSCREEN);
@@ -1814,7 +1814,7 @@ void endscreenPushAnti(void)
 			// Bond - completed
 			if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
 #ifndef PLATFORM_N64
-				|| PLAYERCOUNT() >= 3
+				|| LOCALPLAYERCOUNT() >= 3
 #endif
 			) {
 				menuPushRootDialog(&g_2PMissionEndscreenCompletedVMenuDialog, MENUROOT_MPENDSCREEN);
@@ -1834,7 +1834,7 @@ void endscreenPushAnti(void)
 			// Anti - completed
 			if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
 #ifndef PLATFORM_N64
-				|| PLAYERCOUNT() >= 3
+				|| LOCALPLAYERCOUNT() >= 3
 #endif
 			) {
 				menuPushRootDialog(&g_2PMissionEndscreenCompletedVMenuDialog, MENUROOT_MPENDSCREEN);
@@ -1845,7 +1845,7 @@ void endscreenPushAnti(void)
 			// Anti - failed or aborted
 			if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
 #ifndef PLATFORM_N64
-				|| PLAYERCOUNT() >= 3
+				|| LOCALPLAYERCOUNT() >= 3
 #endif
 			) {
 				menuPushRootDialog(&g_2PMissionEndscreenFailedVMenuDialog, MENUROOT_MPENDSCREEN);

--- a/src/game/endscreen.c
+++ b/src/game/endscreen.c
@@ -292,6 +292,27 @@ char *endscreenMenuTextAccuracy(struct menuitem *item)
 	return g_StringPointer;
 }
 
+#if MAX_COOPCHRS > 2
+static bool enscreenAnyAntiAborted(void) {
+	size_t num;
+
+	if (g_Vars.antiplayernum < 0) {
+		return false;
+	}
+
+	for (num = 0; num < PLAYERCOUNT(); num++) {
+		if (PLAYERNUM_IS_ANTI(num) && g_Vars.players[num] && g_Vars.players[num]->aborted) {
+			return true;
+		}
+	}
+
+	return false;
+}
+#define ANTI_ABORTED() (enscreenAnyAntiAborted())
+#else
+#define ANTI_ABORTED() (g_Vars.anti->aborted)
+#endif
+
 char *endscreenMenuTextMissionStatus(struct menuitem *item)
 {
 	if (g_CheatsActiveBank0 || g_CheatsActiveBank1) {
@@ -312,7 +333,7 @@ char *endscreenMenuTextMissionStatus(struct menuitem *item)
 				return langGet(L_OPTIONS_295); // "Aborted"
 			}
 
-			if (g_Vars.anti->aborted) {
+			if (ANTI_ABORTED()) {
 				return langGet(L_OPTIONS_295); // "Aborted"
 			}
 
@@ -320,7 +341,7 @@ char *endscreenMenuTextMissionStatus(struct menuitem *item)
 				return langGet(L_OPTIONS_293); // "Failed"
 			}
 		} else {
-			if (g_Vars.anti->aborted) {
+			if (ANTI_ABORTED()) {
 				return langGet(L_OPTIONS_295); // "Aborted"
 			}
 
@@ -1795,9 +1816,9 @@ void endscreenPushAnti(void)
 
 	if (g_Vars.currentplayer == g_Vars.bond) {
 #if VERSION >= VERSION_NTSC_1_0 && defined(DEBUG)
-		if (!g_Vars.anti->aborted && (g_Vars.bond->isdead || g_Vars.bond->aborted || !objectiveIsAllComplete()) && !debugIsSetCompleteEnabled())
+		if (!ANTI_ABORTED() && (g_Vars.bond->isdead || g_Vars.bond->aborted || !objectiveIsAllComplete()) && !debugIsSetCompleteEnabled())
 #else
-		if (!g_Vars.anti->aborted && (g_Vars.bond->isdead || g_Vars.bond->aborted || !objectiveIsAllComplete()))
+		if (!ANTI_ABORTED() && (g_Vars.bond->isdead || g_Vars.bond->aborted || !objectiveIsAllComplete()))
 #endif
 		{
 			// Bond - failed or aborted
@@ -1826,9 +1847,9 @@ void endscreenPushAnti(void)
 		filemgrSaveOrLoad(&g_GameFileGuid, FILEOP_SAVE_GAME_000, 0);
 	} else {
 #if VERSION >= VERSION_NTSC_1_0 && defined(DEBUG)
-		if (!g_Vars.anti->aborted && (g_Vars.bond->isdead || g_Vars.bond->aborted || !objectiveIsAllComplete()) && !debugIsSetCompleteEnabled())
+		if (!ANTI_ABORTED() && (g_Vars.bond->isdead || g_Vars.bond->aborted || !objectiveIsAllComplete()) && !debugIsSetCompleteEnabled())
 #else
-		if (!g_Vars.anti->aborted && (g_Vars.bond->isdead || g_Vars.bond->aborted || !objectiveIsAllComplete()))
+		if (!ANTI_ABORTED() && (g_Vars.bond->isdead || g_Vars.bond->aborted || !objectiveIsAllComplete()))
 #endif
 		{
 			// Anti - completed

--- a/src/game/explosions.c
+++ b/src/game/explosions.c
@@ -847,7 +847,7 @@ void explosionInflictDamage(struct prop *expprop)
 						minfrac = (minfrac * 0.7f + 0.3f) * type->damage;
 
 						if (g_Vars.antiplayernum >= 0
-								&& g_Vars.antiplayernum == exp->owner
+								&& EXPLOSION_OWNER_IS_ANTI_PLAYER(exp->owner)
 								&& (obj->flags2 & OBJFLAG2_IMMUNETOANTI)) {
 							// anti cannot damage this obj
 						} else if (isfirstframe) {
@@ -997,8 +997,16 @@ void explosionInflictDamage(struct prop *expprop)
 						ownerprop = g_Vars.bond->prop;
 					} else if (g_Vars.coopplayernum >= 0 && exp->owner == g_Vars.coopplayernum) {
 						ownerprop = g_Vars.coop->prop;
-					} else if (g_Vars.antiplayernum >= 0 && exp->owner == g_Vars.antiplayernum) {
+					} else if (g_Vars.antiplayernum >= 0 && EXPLOSION_OWNER_IS_ANTI_PLAYER(exp->owner)) {
+#if PLATFORM_N64
 						ownerprop = g_Vars.anti->prop;
+#else
+						struct chrdata *ownerchr = mpGetChrFromPlayerIndex(exp->owner);
+
+						if (ownerchr) {
+							ownerprop = ownerchr->prop;
+						}
+#endif
 					}
 
 					chrDamageByExplosion(chr, minfrac, &spa0, ownerprop, &expprop->pos);
@@ -1212,8 +1220,12 @@ u32 explosionTick(struct prop *prop)
 
 			if (g_Vars.normmplayerisrunning) {
 				chr = mpGetChrFromPlayerIndex(exp->owner);
-			} else if (g_Vars.antiplayernum >= 0 && exp->owner == g_Vars.antiplayernum) {
+			} else if (g_Vars.antiplayernum >= 0 && EXPLOSION_OWNER_IS_ANTI_PLAYER(exp->owner)) {
+#if PLATFORM_N64
 				chr = g_Vars.anti->prop->chr;
+#else
+				chr = mpGetChrFromPlayerIndex(exp->owner);
+#endif
 			} else if (g_Vars.coopplayernum >= 0 && exp->owner == g_Vars.coopplayernum) {
 				chr = g_Vars.coop->prop->chr;
 			} else {

--- a/src/game/mainmenu.c
+++ b/src/game/mainmenu.c
@@ -757,7 +757,20 @@ MenuItemHandlerResult menuhandlerAcceptMission(s32 operation, struct menuitem *i
 			}
 
 			g_Vars.coopplayernum = -1;
+#ifdef PLATFORM_N64
 			setNumPlayers(2);
+#else
+			if ((joyGetConnectedControllers() & 0xF) == 0xF) {
+				setNumPlayers(4);
+				g_MpSetup.chrslots = 0xF;
+			} else if ((joyGetConnectedControllers() & 0x7) == 0x7) {
+				setNumPlayers(3);
+				g_MpSetup.chrslots = 0x7;
+			} else {
+				setNumPlayers(2);
+				g_MpSetup.chrslots = 0x3;
+			}
+#endif
 		} else {
 			// Solo
 			g_Vars.bondplayernum = 0;

--- a/src/game/mainmenu.c
+++ b/src/game/mainmenu.c
@@ -748,6 +748,7 @@ MenuItemHandlerResult menuhandlerAcceptMission(s32 operation, struct menuitem *i
 				setNumPlayers(1);
 			}
 		} else if (g_MissionConfig.isanti) {
+#ifdef PLATFORM_N64
 			if (g_Vars.pendingantiplayernum == 1) {
 				g_Vars.bondplayernum = 0;
 				g_Vars.antiplayernum = 1;
@@ -757,9 +758,13 @@ MenuItemHandlerResult menuhandlerAcceptMission(s32 operation, struct menuitem *i
 			}
 
 			g_Vars.coopplayernum = -1;
-#ifdef PLATFORM_N64
+
 			setNumPlayers(2);
 #else
+			g_Vars.bondplayernum = g_Vars.pendingantiplayernum ^ 1;
+			g_Vars.antiplayernum = (g_Vars.bondplayernum == 0 ? 1 : 0);
+			g_Vars.coopplayernum = -1;
+
 			if ((joyGetConnectedControllers() & 0xF) == 0xF) {
 				setNumPlayers(4);
 				g_MpSetup.chrslots = 0xF;
@@ -1558,6 +1563,8 @@ MenuItemHandlerResult menuhandlerAntiRadar(s32 operation, struct menuitem *item,
 	return 0;
 }
 
+#ifdef PLATFORM_N64
+
 MenuItemHandlerResult menuhandlerAntiPlayer(s32 operation, struct menuitem *item, union handlerdata *data)
 {
 	const u16 labels[] = {L_OPTIONS_271, L_OPTIONS_272};
@@ -1623,6 +1630,91 @@ struct menuitem g_AntiOptionsMenuItems[] = {
 	},
 	{ MENUITEMTYPE_END },
 };
+
+#else
+
+MenuItemHandlerResult menuhandlerAntiMainPlayer(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+	static const char *labels[] = {
+		"Player 1",
+		"Player 2",
+		"Player 3",
+		"Player 4",
+	};
+
+	// For consistency with the main save format,
+	// the main player is (pendingantiplayernum XOR 1)
+
+	switch (operation) {
+	case MENUOP_GETOPTIONCOUNT:
+		if ((joyGetConnectedControllers() & 0xF) == 0xF) {
+			data->dropdown.value = 4;
+		} else if ((joyGetConnectedControllers() & 0x7) == 0x7) {
+			data->dropdown.value = 3;
+		} else {
+			data->dropdown.value = 2;
+		}
+		break;
+	case MENUOP_GETOPTIONTEXT:
+		return (s32) (labels[data->dropdown.value]);
+	case MENUOP_SET:
+		g_Vars.pendingantiplayernum = data->dropdown.value ^ 1;
+		g_Vars.modifiedfiles |= MODFILE_GAME;
+		break;
+	case MENUOP_GETSELECTEDINDEX:
+		data->dropdown.value = g_Vars.pendingantiplayernum ^ 1;
+		break;
+	}
+
+	return 0;
+}
+
+struct menuitem g_AntiOptionsMenuItems[] = {
+	{
+		MENUITEMTYPE_CHECKBOX,
+		0,
+		0,
+		L_OPTIONS_267, // "Radar On"
+		0,
+		menuhandlerAntiRadar,
+	},
+	{
+		MENUITEMTYPE_DROPDOWN,
+		0,
+		MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"Main Player",
+		0,
+		menuhandlerAntiMainPlayer,
+	},
+	{
+		MENUITEMTYPE_SEPARATOR,
+		0,
+		0,
+		0,
+		0,
+		NULL,
+	},
+	{
+		MENUITEMTYPE_SELECTABLE,
+		0,
+		0,
+		L_OPTIONS_269, // "Continue"
+		0,
+		menuhandlerBuddyOptionsContinue,
+	},
+	{
+		MENUITEMTYPE_SELECTABLE,
+		0,
+		MENUITEMFLAG_SELECTABLE_CLOSESDIALOG,
+		L_OPTIONS_270, // "Cancel"
+		0,
+		NULL,
+	},
+	{ MENUITEMTYPE_END },
+};
+
+#endif
+
 
 struct menudialogdef g_AntiOptionsMenuDialog = {
 	MENUDIALOGTYPE_DEFAULT,

--- a/src/game/mplayer/ingame.c
+++ b/src/game/mplayer/ingame.c
@@ -802,7 +802,7 @@ void mpPushPauseDialog(void)
 			} else {
 				if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
 #ifndef PLATFORM_N64
-					|| PLAYERCOUNT() >= 3
+					|| LOCALPLAYERCOUNT() >= 3
 #endif
 				) {
 					menuPushRootDialog(&g_2PMissionPauseVMenuDialog, MENUROOT_MPPAUSE);

--- a/src/game/mplayer/ingame.c
+++ b/src/game/mplayer/ingame.c
@@ -800,7 +800,11 @@ void mpPushPauseDialog(void)
 					menuPushRootDialog(&g_MpPausePlayerRankingMenuDialog, MENUROOT_MPPAUSE);
 				}
 			} else {
-				if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL) {
+				if (optionsGetScreenSplit() == SCREENSPLIT_VERTICAL
+#ifndef PLATFORM_N64
+					|| PLAYERCOUNT() >= 3
+#endif
+				) {
 					menuPushRootDialog(&g_2PMissionPauseVMenuDialog, MENUROOT_MPPAUSE);
 				} else {
 					menuPushRootDialog(&g_2PMissionPauseHMenuDialog, MENUROOT_MPPAUSE);

--- a/src/game/mplayer/mplayer.c
+++ b/src/game/mplayer/mplayer.c
@@ -259,7 +259,10 @@ void mpReset(void)
 #ifdef PLATFORM_N64
 	if (g_Vars.coopplayernum >= 0 || g_Vars.antiplayernum >= 0)
 #else
-	if ((g_Vars.coopplayernum >= 0 || g_Vars.antiplayernum >= 0) && getNumPlayers() <= 2)
+	// Counter-Operative now uses a different approach which allows more than 2 players.
+	// Co-Operative, on the other hand, is currently limited to 2 players.
+	// Due to the change in approach, it's better to ignore 2.x controls for Counter-Operative.
+	if (g_Vars.coopplayernum >= 0)
 #endif
 	{
 		struct mpplayerconfig tmp;

--- a/src/game/mplayer/mplayer.c
+++ b/src/game/mplayer/mplayer.c
@@ -1338,11 +1338,7 @@ Gfx *mpRenderModalText(Gfx *gdl)
 			&& g_Vars.currentplayer->redbloodfinished
 			&& g_Vars.currentplayer->deathanimfinished
 			&& !(g_Vars.coopplayernum >= 0 && ((g_Vars.bond->isdead && g_Vars.coop->isdead) || !g_Vars.currentplayer->coopcanrestart || g_InCutscene))
-#ifdef PLATFORM_N64
-			&& !(g_Vars.antiplayernum >= 0 && ((g_Vars.currentplayer != g_Vars.anti || g_InCutscene)))
-#else
-			&& !(g_Vars.antiplayernum >= 0 && ((g_Vars.currentplayer == g_Vars.bond || g_InCutscene)))
-#endif
+			&& !(g_Vars.antiplayernum >= 0 && ((PLAYER_IS_NOT_ANTI(g_Vars.currentplayer) || g_InCutscene)))
 			&& g_NumReasonsToEndMpMatch == 0) {
 		// Render "Press START" text
 		gdl = text0f153628(gdl);

--- a/src/game/mplayer/mplayer.c
+++ b/src/game/mplayer/mplayer.c
@@ -256,7 +256,12 @@ void mpReset(void)
 		g_Vars.lvmpbotlevel = true;
 	}
 
-	if (g_Vars.coopplayernum >= 0 || g_Vars.antiplayernum >= 0) {
+#ifdef PLATFORM_N64
+	if (g_Vars.coopplayernum >= 0 || g_Vars.antiplayernum >= 0)
+#else
+	if ((g_Vars.coopplayernum >= 0 || g_Vars.antiplayernum >= 0) && getNumPlayers() <= 2)
+#endif
+	{
 		struct mpplayerconfig tmp;
 
 		tmp = g_PlayerConfigsArray[MAX_PLAYERS];
@@ -1333,7 +1338,11 @@ Gfx *mpRenderModalText(Gfx *gdl)
 			&& g_Vars.currentplayer->redbloodfinished
 			&& g_Vars.currentplayer->deathanimfinished
 			&& !(g_Vars.coopplayernum >= 0 && ((g_Vars.bond->isdead && g_Vars.coop->isdead) || !g_Vars.currentplayer->coopcanrestart || g_InCutscene))
+#ifdef PLATFORM_N64
 			&& !(g_Vars.antiplayernum >= 0 && ((g_Vars.currentplayer != g_Vars.anti || g_InCutscene)))
+#else
+			&& !(g_Vars.antiplayernum >= 0 && ((g_Vars.currentplayer == g_Vars.bond || g_InCutscene)))
+#endif
 			&& g_NumReasonsToEndMpMatch == 0) {
 		// Render "Press START" text
 		gdl = text0f153628(gdl);

--- a/src/game/player.c
+++ b/src/game/player.c
@@ -606,7 +606,13 @@ void playerStartNewLife(void)
 		if (cmd);
 		if (cmd);
 
-		if (g_Vars.antiplayernum < 0 || g_Vars.currentplayer != g_Vars.anti) {
+		if (g_Vars.antiplayernum < 0
+#ifdef PLATFORM_N64
+				|| g_Vars.currentplayer != g_Vars.anti
+#else
+				|| g_Vars.currentplayer == g_Vars.bond
+#endif
+				) {
 			while (cmd[0] != INTROCMD_END) {
 				switch (cmd[0]) {
 				case INTROCMD_SPAWN:
@@ -980,7 +986,13 @@ void playerSpawn(void)
 	}
 
 	if (g_Vars.mplayerisrunning) {
-		if (g_Vars.antiplayernum >= 0 && g_Vars.currentplayer == g_Vars.anti) {
+		if (g_Vars.antiplayernum >= 0
+#ifdef PLATFORM_N64
+				&& g_Vars.currentplayer == g_Vars.anti
+#else
+				&& g_Vars.currentplayer != g_Vars.bond
+#endif
+				) {
 			numsqdists = 0;
 			force = false;
 
@@ -1182,7 +1194,11 @@ void playerChooseBodyAndHead(s32 *bodynum, s32 *headnum, s32 *arg2)
 	bool solo;
 
 	if (g_Vars.antiplayernum >= 0
+#ifdef PLATFORM_N64
 			&& g_Vars.currentplayer == g_Vars.anti
+#else
+			&& g_Vars.currentplayer != g_Vars.bond
+#endif
 			&& g_Vars.antiheadnum >= 0
 			&& g_Vars.antibodynum >= 0) {
 		*headnum = g_Vars.antiheadnum;
@@ -1514,7 +1530,11 @@ void playerTickChrBody(void)
 
 #if VERSION >= VERSION_NTSC_1_0
 		if (g_Vars.antiplayernum >= 0
+#ifdef PLATFORM_N64
 				&& g_Vars.currentplayer == g_Vars.anti
+#else
+				&& g_Vars.currentplayer != g_Vars.bond
+#endif
 				&& g_Vars.currentplayer->vv_eyeheight > 159) {
 			g_Vars.currentplayer->vv_eyeheight = 159;
 		}
@@ -4713,7 +4733,13 @@ Gfx *playerRenderHud(Gfx *gdl)
 							chr->chrflags |= CHRCFLAG_HIDDEN;
 						}
 
-						if (g_Vars.antiplayernum >= 0 && g_Vars.currentplayer == g_Vars.anti) {
+						if (g_Vars.antiplayernum >= 0
+#ifdef PLATFORM_N64
+								&& g_Vars.currentplayer == g_Vars.anti
+#else
+								&& g_Vars.currentplayer != g_Vars.bond
+#endif
+								) {
 							// Anti
 #ifndef PLATFORM_N64
 							if (g_NetMode == NETMODE_SERVER && g_Vars.currentplayer->isremote) {

--- a/src/game/player.c
+++ b/src/game/player.c
@@ -606,13 +606,7 @@ void playerStartNewLife(void)
 		if (cmd);
 		if (cmd);
 
-		if (g_Vars.antiplayernum < 0
-#ifdef PLATFORM_N64
-				|| g_Vars.currentplayer != g_Vars.anti
-#else
-				|| g_Vars.currentplayer == g_Vars.bond
-#endif
-				) {
+		if (g_Vars.antiplayernum < 0 || PLAYER_IS_NOT_ANTI(g_Vars.currentplayer)) {
 			while (cmd[0] != INTROCMD_END) {
 				switch (cmd[0]) {
 				case INTROCMD_SPAWN:
@@ -986,13 +980,7 @@ void playerSpawn(void)
 	}
 
 	if (g_Vars.mplayerisrunning) {
-		if (g_Vars.antiplayernum >= 0
-#ifdef PLATFORM_N64
-				&& g_Vars.currentplayer == g_Vars.anti
-#else
-				&& g_Vars.currentplayer != g_Vars.bond
-#endif
-				) {
+		if (g_Vars.antiplayernum >= 0 && PLAYER_IS_ANTI(g_Vars.currentplayer)) {
 			numsqdists = 0;
 			force = false;
 
@@ -1194,11 +1182,7 @@ void playerChooseBodyAndHead(s32 *bodynum, s32 *headnum, s32 *arg2)
 	bool solo;
 
 	if (g_Vars.antiplayernum >= 0
-#ifdef PLATFORM_N64
-			&& g_Vars.currentplayer == g_Vars.anti
-#else
-			&& g_Vars.currentplayer != g_Vars.bond
-#endif
+			&& PLAYER_IS_ANTI(g_Vars.currentplayer)
 			&& g_Vars.antiheadnum >= 0
 			&& g_Vars.antibodynum >= 0) {
 		*headnum = g_Vars.antiheadnum;
@@ -1530,11 +1514,7 @@ void playerTickChrBody(void)
 
 #if VERSION >= VERSION_NTSC_1_0
 		if (g_Vars.antiplayernum >= 0
-#ifdef PLATFORM_N64
-				&& g_Vars.currentplayer == g_Vars.anti
-#else
-				&& g_Vars.currentplayer != g_Vars.bond
-#endif
+				&& PLAYER_IS_ANTI(g_Vars.currentplayer)
 				&& g_Vars.currentplayer->vv_eyeheight > 159) {
 			g_Vars.currentplayer->vv_eyeheight = 159;
 		}
@@ -4733,13 +4713,7 @@ Gfx *playerRenderHud(Gfx *gdl)
 							chr->chrflags |= CHRCFLAG_HIDDEN;
 						}
 
-						if (g_Vars.antiplayernum >= 0
-#ifdef PLATFORM_N64
-								&& g_Vars.currentplayer == g_Vars.anti
-#else
-								&& g_Vars.currentplayer != g_Vars.bond
-#endif
-								) {
+						if (g_Vars.antiplayernum >= 0 && PLAYER_IS_ANTI(g_Vars.currentplayer)) {
 							// Anti
 #ifndef PLATFORM_N64
 							if (g_NetMode == NETMODE_SERVER && g_Vars.currentplayer->isremote) {

--- a/src/game/playerreset.c
+++ b/src/game/playerreset.c
@@ -186,13 +186,7 @@ void playerReset(void)
 				cmd = (struct cmd32 *)((uintptr_t)cmd + 8);
 				break;
 			case INTROCMD_WEAPON:
-				if (cmd->param3 == 0
-#ifdef PLATFORM_N64
-						&& g_Vars.currentplayer != g_Vars.anti
-#else
-						&& (g_Vars.antiplayernum < 0 || g_Vars.currentplayer == g_Vars.bond)
-#endif
-						) {
+				if (cmd->param3 == 0 && PLAYER_IS_NOT_ANTI(g_Vars.currentplayer)) {
 
 					modelmgrLoadProjectileModeldefs(cmd->param1);
 
@@ -220,13 +214,7 @@ void playerReset(void)
 				cmd = (struct cmd32 *)((uintptr_t)cmd + 16);
 				break;
 			case INTROCMD_AMMO:
-				if (cmd->param3 == 0
-#ifdef PLATFORM_N64
-						&& g_Vars.currentplayer != g_Vars.anti
-#else
-						&& (g_Vars.antiplayernum < 0 || g_Vars.currentplayer == g_Vars.bond)
-#endif
-						) {
+				if (cmd->param3 == 0 && PLAYER_IS_NOT_ANTI(g_Vars.currentplayer)) {
 					bgunSetAmmoQuantity(cmd->param1, cmd->param2);
 				}
 				cmd = (struct cmd32 *)((uintptr_t)cmd + 16);

--- a/src/game/playerreset.c
+++ b/src/game/playerreset.c
@@ -186,7 +186,14 @@ void playerReset(void)
 				cmd = (struct cmd32 *)((uintptr_t)cmd + 8);
 				break;
 			case INTROCMD_WEAPON:
-				if (cmd->param3 == 0 && g_Vars.currentplayer != g_Vars.anti) {
+				if (cmd->param3 == 0
+#ifdef PLATFORM_N64
+						&& g_Vars.currentplayer != g_Vars.anti
+#else
+						&& (g_Vars.antiplayernum < 0 || g_Vars.currentplayer == g_Vars.bond)
+#endif
+						) {
+
 					modelmgrLoadProjectileModeldefs(cmd->param1);
 
 					if (cmd->param2 >= 0) {
@@ -213,7 +220,13 @@ void playerReset(void)
 				cmd = (struct cmd32 *)((uintptr_t)cmd + 16);
 				break;
 			case INTROCMD_AMMO:
-				if (cmd->param3 == 0 && g_Vars.currentplayer != g_Vars.anti) {
+				if (cmd->param3 == 0
+#ifdef PLATFORM_N64
+						&& g_Vars.currentplayer != g_Vars.anti
+#else
+						&& (g_Vars.antiplayernum < 0 || g_Vars.currentplayer == g_Vars.bond)
+#endif
+						) {
 					bgunSetAmmoQuantity(cmd->param1, cmd->param2);
 				}
 				cmd = (struct cmd32 *)((uintptr_t)cmd + 16);

--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -2358,11 +2358,7 @@ void propsTestForPickup(void)
 
 	if (g_Vars.currentplayer->bondmovemode != MOVEMODE_CUTSCENE
 			&& !g_PlayerInvincible
-#ifdef PLATFORM_N64
-			&& g_Vars.currentplayer != g_Vars.anti
-#else
-			&& (g_Vars.antiplayernum < 0 || g_Vars.currentplayer == g_Vars.bond)
-#endif
+			&& PLAYER_IS_NOT_ANTI(g_Vars.currentplayer)
 			) {
 		roomsCopy(g_Vars.currentplayer->prop->rooms, allrooms);
 

--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -2358,7 +2358,12 @@ void propsTestForPickup(void)
 
 	if (g_Vars.currentplayer->bondmovemode != MOVEMODE_CUTSCENE
 			&& !g_PlayerInvincible
-			&& g_Vars.currentplayer != g_Vars.anti) {
+#ifdef PLATFORM_N64
+			&& g_Vars.currentplayer != g_Vars.anti
+#else
+			&& (g_Vars.antiplayernum < 0 || g_Vars.currentplayer == g_Vars.bond)
+#endif
+			) {
 		roomsCopy(g_Vars.currentplayer->prop->rooms, allrooms);
 
 		for (i = 0; g_Vars.currentplayer->prop->rooms[i] != -1; i++) {

--- a/src/game/propobj.c
+++ b/src/game/propobj.c
@@ -15942,7 +15942,14 @@ void objHit(struct shotdata *shotdata, struct hit *hit)
 		}
 	}
 
-	if (g_Vars.antiplayernum < 0 || g_Vars.currentplayer != g_Vars.anti || (obj->flags2 & OBJFLAG2_IMMUNETOANTI) == 0) {
+	if (g_Vars.antiplayernum < 0
+#ifdef PLATFORM_N64
+			|| g_Vars.currentplayer != g_Vars.anti
+#else
+			|| g_Vars.currentplayer == g_Vars.bond
+#endif
+			|| (obj->flags2 & OBJFLAG2_IMMUNETOANTI) == 0) {
+
 		if (hit->hitthing.texturenum != 10000) {
 			f32 damage = gsetGetDamage(&shotdata->gset);
 

--- a/src/game/propobj.c
+++ b/src/game/propobj.c
@@ -9148,7 +9148,7 @@ void autogunTickShoot(struct prop *autogunprop)
 				// (ie. autogun is a Defense autogun or a thrown laptop)
 				if (g_Vars.normmplayerisrunning
 						|| (targetprop && (targetprop->type == PROPTYPE_CHR))
-						|| (g_Vars.antiplayernum >= 0 && targetprop && targetprop == g_Vars.anti->prop)) {
+						|| (g_Vars.antiplayernum >= 0 && targetprop && PROP_IS_FOR_ANTI_PLAYER(targetprop))) {
 					if (cdExamLos08(&gunpos, gunrooms, &hitpos, CDTYPE_ALL, GEOFLAG_BLOCK_SHOOT) == CDRESULT_COLLISION) {
 #if VERSION >= VERSION_PAL_FINAL
 						cdGetPos(&hitpos, 11480, "prop/propobj.c");
@@ -15943,11 +15943,7 @@ void objHit(struct shotdata *shotdata, struct hit *hit)
 	}
 
 	if (g_Vars.antiplayernum < 0
-#ifdef PLATFORM_N64
-			|| g_Vars.currentplayer != g_Vars.anti
-#else
-			|| g_Vars.currentplayer == g_Vars.bond
-#endif
+			|| PLAYER_IS_NOT_ANTI(g_Vars.currentplayer)
 			|| (obj->flags2 & OBJFLAG2_IMMUNETOANTI) == 0) {
 
 		if (hit->hitthing.texturenum != 10000) {

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -20,7 +20,11 @@
 #define MAX_CHRWAYPOINTS       6
 #define MAX_EXPLOSIONS         6
 #define MAX_EYESPYDARTS        8
+#ifdef PLATFORM_N64
+#define MAX_COOPCHRS           2
+#else
 #define MAX_COOPCHRS           MAX_PLAYERS
+#endif
 #define MAX_MPCHRS             (MAX_PLAYERS + MAX_BOTS)
 #define MAX_MPPLAYERCONFIGS    (MAX_PLAYERS + MAX_COOPCHRS)
 #define MAX_OBJECTIVES         10
@@ -82,14 +86,16 @@
 #define PLAYERCOUNT()       1
 #endif
 
-#if MAX_LOCAL_PLAYERS > 2
+#if MAX_COOPCHRS > 2
 #define PLAYER_IS_ANTI(plr) (g_Vars.antiplayernum >= 0 && (plr) != g_Vars.bond)
 #define PLAYER_IS_NOT_ANTI(plr) (g_Vars.antiplayernum < 0 || (plr) == g_Vars.bond)
+#define PLAYERNUM_IS_ANTI(plrnum) (g_Vars.antiplayernum >= 0 && (plrnum) != g_Vars.bondplayernum)
 #define PROP_IS_FOR_ANTI_PLAYER(plrprop) (g_Vars.antiplayernum >= 0 && g_Vars.anti && (plrprop)->type == PROPTYPE_PLAYER && (plrprop) != g_Vars.bond->prop)
 #define EXPLOSION_OWNER_IS_ANTI_PLAYER(expowner) (g_Vars.antiplayernum >= 0 && (expowner) != g_Vars.bondplayernum && mpGetChrFromPlayerIndex((expowner)) != NULL)
 #else
 #define PLAYER_IS_ANTI(plr) ((plr) == g_Vars.anti)
 #define PLAYER_IS_NOT_ANTI(plr) ((plr) != g_Vars.anti)
+//define PLAYERNUM_IS_ANTI(plrnum) ((plrnum) == g_Vars.antiplayernum)
 #define PROP_IS_FOR_ANTI_PLAYER(plrprop) ((plrprop) == g_Vars.anti->prop)
 #define EXPLOSION_OWNER_IS_ANTI_PLAYER(expowner) ((expowner) == g_Vars.antiplayernum)
 #endif

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -20,8 +20,9 @@
 #define MAX_CHRWAYPOINTS       6
 #define MAX_EXPLOSIONS         6
 #define MAX_EYESPYDARTS        8
+#define MAX_COOPCHRS           MAX_PLAYERS
 #define MAX_MPCHRS             (MAX_PLAYERS + MAX_BOTS)
-#define MAX_MPPLAYERCONFIGS    (MAX_PLAYERS + 2)
+#define MAX_MPPLAYERCONFIGS    (MAX_PLAYERS + MAX_COOPCHRS)
 #define MAX_OBJECTIVES         10
 #define MAX_LOCAL_PLAYERS      4
 #define MAX_PLAYERS            8

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -82,6 +82,18 @@
 #define PLAYERCOUNT()       1
 #endif
 
+#if MAX_LOCAL_PLAYERS > 2
+#define PLAYER_IS_ANTI(plr) (g_Vars.antiplayernum >= 0 && (plr) != g_Vars.bond)
+#define PLAYER_IS_NOT_ANTI(plr) (g_Vars.antiplayernum < 0 || (plr) == g_Vars.bond)
+#define PROP_IS_FOR_ANTI_PLAYER(plrprop) (g_Vars.antiplayernum >= 0 && g_Vars.anti && (plrprop)->type == PROPTYPE_PLAYER && (plrprop) != g_Vars.bond->prop)
+#define EXPLOSION_OWNER_IS_ANTI_PLAYER(expowner) (g_Vars.antiplayernum >= 0 && (expowner) != g_Vars.bondplayernum && mpGetChrFromPlayerIndex((expowner)) != NULL)
+#else
+#define PLAYER_IS_ANTI(plr) ((plr) == g_Vars.anti)
+#define PLAYER_IS_NOT_ANTI(plr) ((plr) != g_Vars.anti)
+#define PROP_IS_FOR_ANTI_PLAYER(plrprop) ((plrprop) == g_Vars.anti->prop)
+#define EXPLOSION_OWNER_IS_ANTI_PLAYER(expowner) ((expowner) == g_Vars.antiplayernum)
+#endif
+
 #define VALIDWEAPON()       (g_Vars.currentplayer->gunctrl.weaponnum >= WEAPON_UNARMED && g_Vars.currentplayer->gunctrl.weaponnum <= WEAPON_COMBATBOOST)
 #define FUNCISSEC()         (VALIDWEAPON() && (g_PlayerConfigsArray[g_Vars.currentplayerstats->mpindex].gunfuncs[(g_Vars.currentplayer->gunctrl.weaponnum - 1) >> 3] & (1 << ((g_Vars.currentplayer->gunctrl.weaponnum - 1) & 7))))
 


### PR DESCRIPTION
Well, where do we start... This extends counter-op mode to up to 4 local players, and the only reason for it being 4 is because that's the practical limit on the number of local players. Trying to go beyond 4 players for split-screen would require extra design work including making menus even narrower than what's offered in vertical split mode.

But for netplay integration purposes (not implemented yet!), going beyond 4 players should not be (much of) a problem.

At this stage it's quite playable. There are a few subtle cases of jank which most people aren't going to hit, and if you know about some of them then it's best to make sure that you're playing with people who are at least mature enough to not try to ruin the game.

Ref: #383 (extended *co-op* mode + what that would entail, and some elaboration on what that would take for counter-op and why counter-op mode is easier to implement)

----

Here's what's implemented:

- A bunch of logic which determines whether a player is a protagonist or an antagonist has been inverted from "is anti player" to "is not bond player". In practice, this needed to be inverted in about 20 different places.
- Instead of selecting the counter-operative player from a list of 2 players, you select the main player from a list of 2 through 4 players.
- 3-way and 4-way split screen now uses the narrower UI windows normally used in vertical split mode. This constraint is used for all relevant UI windows in Combat Simulator, but was missing on a few that don't show up (which I think was: objectives, briefing, results).
- `set_chr_team(CHR_ANTI, TEAM_*)` has been special-cased to set the team of all enemy players. At the very least, it stops enemy players from autoaiming at each other. Levels where this has an effect: Villa, Chicago, Rescue, Air Base, Air Force One.

----

And now for a list of known (and likely) issues!

- This doesn't add another flag for the save file to handle an extra bit for selecting the current player, so if you pick anything other than Player 1 as the main player, then reloading the program will select Player 2. At least I think that's what it picks.
- ~~This expects players to be allocated sequentially. If you have Players 1, 2, and 4, it will assume you only have 2 players.~~ Fixed in a later commit.
- ~~On the other hand... if you have 4 players plugged in, you will have 4 players, even if you only want to do a 2- or 3-player game. I don't have an option to reduce that down yet.~~ Fixed in a later commit.
- 2.x control schemes will probably break. [UPDATE: I've forced it to use the combat simulator way of assigning inputs, but 2.x may still break.]

And here's the per-level issues I've left in because they can be dealt to later and most of them are minor:

- Investigation: Radiation only affects the first of the enemy players, not any of the extra enemy players. (This is the most annoying one to attempt to fix, and will require this level to be special-cased.)
- Chicago: If any extra enemy player dies in front of the building entrance guard, the entrance is sealed. (I actually tried to fix this one, but setting the teams correctly isn't enough for this.)
- *Rescue: This was an issue earlier on, but there was a way for an extra enemy player to destroy the crate which involved the Dragon's secondary proxy mine function. There might be a vanilla bug somewhere. Either way, I hit this bug before inverting the explosion counter-op player logic. (Also, who even uses the crate, anyway?)*
- Deep Sea: The extra enemy players are not marked as invincible during the outro. I'm not sure if this actually has any effect, however - it looks like all players are made invisible and possibly even invincible during cutscenes, but I haven't looked at the code so can't say for sure.
- CI Defense: If the bomb explodes, an explosion will only be created around the main player and the first enemy player. The mission is still eventually explicitly failed.
- Various levels: Certain things are prevented from appearing or disappearing when either the main player, the co-op player, or the first enemy player are in certain locations. Currently, the extra enemy players are not factored in. The cases I'm aware of are:
  - Extraction: Cassandra disappearing (ironically this is bugged in co-op, as from what I can tell, the guard ends up being: `if (!(anti || (bond && coop))) disappear();`)
  - Air Base: Certain characters appearing or disappearing during the takeover
  - CI Defense: The bomb and 6 Mr. Blondes appearing; Hostages unloading
  - Attack Ship: Elvis and Maians appearing... and there's something to do with some "shy Skedar" thing
  - Maian SOS: Characters from the first part of the level being unloaded

Lastly, a bug that isn't ours:

- Attack Ship has some `if_chr_activated_object(CHR_ANTI, ...)` calls which has something to do with some of the lifts in the level, but the actual implementation can only handle the case of the main player and the coop player. So these actually do nothing.