### PR TITLE
Makefile.port: fix dependencies for parallel compilation

### DIFF
--- a/Makefile.port
+++ b/Makefile.port
@@ -271,7 +271,7 @@ export ROMID
 
 BIN := $(B_DIR)/$(BIN_NAME)
 
-default: $(JSON_HEADERS) $(BIN)
+default: $(BIN)
 
 ################################################################################
 # Asset Manager header generation
@@ -309,11 +309,11 @@ ifneq ($(CV2PDB),)
 	$(CV2PDB) $(BIN)
 endif
 
-$(B_DIR)/%.o: %.c
+$(B_DIR)/%.o: %.c $(JSON_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CC) -c $(CFLAGS) $(OPT_LVL) -o $@ $<
 
-$(B_DIR)/%.o: %.cpp
+$(B_DIR)/%.o: %.cpp $(JSON_HEADERS)
 	@mkdir -p $(dir $@)
 	$(CXX) -c $(CXXFLAGS) $(OPT_LVL) -o $@ $<
 


### PR DESCRIPTION
I'm packaging your project for NixOS and I found that the build sometimes fails when parallel compilation is enabled.

It fails with errors like:
```
fatal error: tiles/ame.h: No such file or directory
```

This change ensures the json headers to be built before the `.c` and `.cpp` are built.