### PR TITLE
Add experimental Slayer All Guns option

### DIFF
--- a/port/src/main.c
+++ b/port/src/main.c
@@ -37,6 +37,7 @@ u8 g_VmShowStats = 0;
 
 s32 g_TickRateDiv = 1;
 s32 g_TickExtraSleep = true;
+s32 g_AllGunsSlayer = false;
 
 s32 g_SkipIntro = false;
 
@@ -169,6 +170,7 @@ PD_CONSTRUCTOR static void gameConfigInit(void)
 	configRegisterInt("Game.SkipIntro", &g_SkipIntro, 0, 1);
 	configRegisterInt("Game.DisableMpDeathMusic", &g_MusicDisableMpDeath, 0, 1);
 	configRegisterInt("Game.GEMuzzleFlashes", &g_BgunGeMuzzleFlashes, 0, 1);
+	configRegisterInt("Game.AllGunsSlayer", &g_AllGunsSlayer, 0, 1);
 	configRegisterInt("Game.MaxExplosions", &g_MaxExplosions, 6, 96);
 	for (s32 j = 0; j < MAX_PLAYERS; ++j) {
 		const s32 i = j + 1;

--- a/port/src/optionsmenu.c
+++ b/port/src/optionsmenu.c
@@ -1936,6 +1936,56 @@ static MenuItemHandlerResult menuhandlerOpenGameMenu(s32 operation, struct menui
 	return 0;
 }
 
+static MenuItemHandlerResult menuhandlerAllGunsSlayer(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+	switch (operation) {
+	case MENUOP_GET:
+		return g_AllGunsSlayer;
+	case MENUOP_SET:
+		g_AllGunsSlayer = data->checkbox.value;
+		break;
+	}
+
+	return 0;
+}
+
+struct menuitem g_ExtendedExperimentalMenuItems[] = {
+	{
+		MENUITEMTYPE_CHECKBOX,
+		0,
+		MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"Add Slayer to \"All Guns\" cheat",
+		0,
+		menuhandlerAllGunsSlayer,
+	},
+	{
+		MENUITEMTYPE_SEPARATOR,
+		0,
+		0,
+		0,
+		0,
+		NULL,
+	},
+	{
+		MENUITEMTYPE_SELECTABLE,
+		0,
+		MENUITEMFLAG_SELECTABLE_CLOSESDIALOG,
+		L_OPTIONS_213, // "Back"
+		0,
+		NULL,
+	},
+	{ MENUITEMTYPE_END },
+};
+
+struct menudialogdef g_ExtendedExperimentalMenuDialog = {
+	MENUDIALOGTYPE_DEFAULT,
+	(uintptr_t)"Experimental Options",
+	g_ExtendedExperimentalMenuItems,
+	NULL,
+	MENUDIALOGFLAG_LITERAL_TEXT,
+	NULL,
+};
+
 static MenuItemHandlerResult menuhandlerOpenBindsMenu(s32 operation, struct menuitem *item, union handlerdata *data)
 {
 	if (operation == MENUOP_SET) {
@@ -1993,6 +2043,14 @@ struct menuitem g_ExtendedMenuItems[] = {
 		(uintptr_t)"Key Bindings\n",
 		0,
 		menuhandlerOpenBindsMenu,
+	},
+	{
+		MENUITEMTYPE_SELECTABLE,
+		0,
+		MENUITEMFLAG_SELECTABLE_OPENSDIALOG | MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"Experimental\n",
+		0,
+		(void *)&g_ExtendedExperimentalMenuDialog,
 	},
 	{
 		MENUITEMTYPE_SEPARATOR,

--- a/src/game/inv.c
+++ b/src/game/inv.c
@@ -280,11 +280,13 @@ s32 invAddOneIfCantHaveSlayer(s32 index)
 {
 	if (mainGetStageNum());
 
+#ifdef PLATFORM_N64
 	if (mainGetStageNum() != STAGE_ATTACKSHIP
 			&& mainGetStageNum() != STAGE_SKEDARRUINS
 			&& index >= WEAPON_SLAYER) {
 		index++;
 	}
+#endif
 
 #if (VERSION >= VERSION_JPN_FINAL) && defined(PLATFORM_N64)
 	if (index >= 26) {
@@ -299,9 +301,11 @@ s32 currentStageForbidsSlayer(void)
 {
 	bool value = VERSION >= VERSION_JPN_FINAL ? 1 : 0;
 
+#ifdef PLATFORM_N64
 	if (mainGetStageNum() != STAGE_ATTACKSHIP && mainGetStageNum() != STAGE_SKEDARRUINS) {
 		value++;
 	}
+#endif
 
 	return value;
 }
@@ -316,9 +320,11 @@ bool invCanHaveAllGunsWeapon(s32 weaponnum)
 	}
 #endif
 
+#ifdef PLATFORM_N64
 	if (weaponnum == WEAPON_SLAYER) {
 		canhave = false;
 	}
+#endif
 
 	// @bug: The stage conditions need an OR. This condition can never pass.
 	if ((mainGetStageNum() == STAGE_ATTACKSHIP && mainGetStageNum() == STAGE_SKEDARRUINS)

--- a/src/game/inv.c
+++ b/src/game/inv.c
@@ -276,11 +276,21 @@ bool invHasSingleWeaponOrProp(s32 weaponnum)
 	return false;
 }
 
+static bool invShouldSkipSlayerInAllGuns(void)
+{
+#ifdef PLATFORM_N64
+	return true;
+#else
+	return !g_AllGunsSlayer;
+#endif
+}
+
 s32 invAddOneIfCantHaveSlayer(s32 index)
 {
 	if (mainGetStageNum());
 
-	if (mainGetStageNum() != STAGE_ATTACKSHIP
+	if (invShouldSkipSlayerInAllGuns()
+			&& mainGetStageNum() != STAGE_ATTACKSHIP
 			&& mainGetStageNum() != STAGE_SKEDARRUINS
 			&& index >= WEAPON_SLAYER) {
 		index++;
@@ -299,7 +309,9 @@ s32 currentStageForbidsSlayer(void)
 {
 	bool value = VERSION >= VERSION_JPN_FINAL ? 1 : 0;
 
-	if (mainGetStageNum() != STAGE_ATTACKSHIP && mainGetStageNum() != STAGE_SKEDARRUINS) {
+	if (invShouldSkipSlayerInAllGuns()
+			&& mainGetStageNum() != STAGE_ATTACKSHIP
+			&& mainGetStageNum() != STAGE_SKEDARRUINS) {
 		value++;
 	}
 
@@ -316,7 +328,7 @@ bool invCanHaveAllGunsWeapon(s32 weaponnum)
 	}
 #endif
 
-	if (weaponnum == WEAPON_SLAYER) {
+	if (invShouldSkipSlayerInAllGuns() && weaponnum == WEAPON_SLAYER) {
 		canhave = false;
 	}
 

--- a/src/include/data.h
+++ b/src/include/data.h
@@ -558,6 +558,7 @@ extern s32 g_TickExtraSleep;
 extern s32 g_MusicDisableMpDeath;
 extern s32 g_BgunGeMuzzleFlashes;
 extern s32 g_FileAutoSelect;
+extern s32 g_AllGunsSlayer;
 
 extern u8 g_MpWeaponSetRandomFilters[NUM_MPWEAPONS];
 extern s32 g_MpWeaponRandomFilterNum;


### PR DESCRIPTION
## Summary
- Adds an `Experimental` submenu under Extended Options for opt-in behavior that may affect gameplay.
- Adds `Add Slayer to "All Guns" cheat`, backed by the new `Game.AllGunsSlayer` config key.
- Defaults the option off, preserving the original All Guns behavior unless users explicitly opt in.
- Keeps N64 behavior unchanged.

<img width="752" height="620" alt="Screenshot 2026-06-21 at 12 48 41" src="https://github.com/user-attachments/assets/81d23436-950c-4785-982e-1da192215782" />
<img width="752" height="620" alt="Screenshot 2026-06-21 at 12 48 45" src="https://github.com/user-attachments/assets/6fe0e88d-4d80-4f8e-96a4-5c93bda1010d" />


## Testing
- `cmake --build build -j4`
- `git diff --check`

## Notes
This creates a dedicated Experimental menu that future PRs can build on for other opt-in/game-breaking port options.