### PR TITLE
Make "All Guns in Solo" cheat work in multiplayer

### DIFF
--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -165,6 +165,17 @@ void cheatActivate(s32 cheat_id)
 		setCurrentPlayerNum(prevplayernum);
 		break;
 	case CHEAT_ALLGUNS:
+#ifndef PLATFORM_N64
+		// Give all guns to all players
+		prevplayernum = g_Vars.currentplayernum;
+
+		for (playernum = 0; playernum < PLAYERCOUNT(); playernum++) {
+			setCurrentPlayerNum(playernum);
+			invSetAllGuns(true);
+		}
+
+		setCurrentPlayerNum(prevplayernum);
+#else
 		// Give all guns if only one player playing
 		if (PLAYERCOUNT() == 1 && g_Vars.normmplayerisrunning == false) {
 			prevplayernum = g_Vars.currentplayernum;
@@ -176,6 +187,7 @@ void cheatActivate(s32 cheat_id)
 
 			setCurrentPlayerNum(prevplayernum);
 		}
+#endif
 		break;
 	}
 
@@ -203,6 +215,16 @@ void cheatDeactivate(s32 cheat_id)
 		setCurrentPlayerNum(prevplayernum);
 		break;
 	case CHEAT_ALLGUNS:
+#ifndef PLATFORM_N64
+		prevplayernum = g_Vars.currentplayernum;
+
+		for (playernum = 0; playernum < PLAYERCOUNT(); playernum++) {
+			setCurrentPlayerNum(playernum);
+			invSetAllGuns(false);
+		}
+
+		setCurrentPlayerNum(prevplayernum);
+#else
 		if (PLAYERCOUNT() == 1 && g_Vars.normmplayerisrunning == false) {
 			prevplayernum = g_Vars.currentplayernum;
 
@@ -213,6 +235,7 @@ void cheatDeactivate(s32 cheat_id)
 
 			setCurrentPlayerNum(prevplayernum);
 		}
+#endif
 		break;
 	}
 

--- a/src/game/invreset.c
+++ b/src/game/invreset.c
@@ -12,11 +12,15 @@ void invReset(void)
 {
 	s32 i;
 
+#ifndef PLATFORM_N64
+	g_Vars.currentplayer->equipallguns = cheatIsActive(CHEAT_ALLGUNS);
+#else
 	if (PLAYERCOUNT() == 1 && g_Vars.normmplayerisrunning == false) {
 		g_Vars.currentplayer->equipallguns = cheatIsActive(CHEAT_ALLGUNS);
 	} else {
 		g_Vars.currentplayer->equipallguns = false;
 	}
+#endif
 
 	for (i = 0; i != ARRAYCOUNT(g_Vars.currentplayer->gunheldarr); i++) {
 		g_Vars.currentplayer->gunheldarr[i].totaltime240_60 = -1;


### PR DESCRIPTION
This one always frustrated me as a kid. Why is "All Guns" restricted to the single player mode? I'm gonna guess to not overload the N64's RAM. Not a problem anymore on PC so let's make "All Guns" work for all players in all modes. This works for co-op and combat simulator (and probably counter-op too, I didn't test).

We could potentially refine this further to exclude the "Psychosis Gun" in Combat Simulator since it doesn't seem useful there (I didn't test its effect).

![Screenshot 2024-05-19 202037](https://github.com/fgsfdsfgs/perfect_dark/assets/1617767/3671b82a-2e5a-48c4-8cd0-790067cf4ddb)

TODO:
- [ ] Change string from "All Guns in Solo" to just "All Guns". I couldn't figure out how to do that. I tried changing the strings in the json asset files but that didn't work. Does anyone know how to do that?
