### PR TITLE
Remove Psychosis Gun ammo limit

### DIFF
--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -12275,7 +12275,9 @@ bool bgunAmmotypeAllowsUnlimitedAmmo(u32 ammotype)
 			return false;
 		}
 		break;
+#ifdef PLATFORM_N64
 	case AMMOTYPE_PSYCHOSIS:
+#endif
 	case AMMOTYPE_17:
 	case AMMOTYPE_BUG:
 	case AMMOTYPE_MICROCAMERA:


### PR DESCRIPTION
Have as many allies as you want! I'm guessing the limit on the N64 was for RAM reasons, which isn't an issue anymore! Let's have as many allies as we want! You can now have your own personal army following you around.

![Screenshot 2024-05-19 203703](https://github.com/fgsfdsfgs/perfect_dark/assets/1617767/9ad36a76-4312-48f7-9b55-14529fbffaaa)
