### PR TITLE
Allow Slayer missiles to go out of bounds for exploration

### DIFF
--- a/src/game/inv.c
+++ b/src/game/inv.c
@@ -280,11 +280,13 @@ s32 invAddOneIfCantHaveSlayer(s32 index)
 {
 	if (mainGetStageNum());
 
+#ifdef PLATFORM_N64
 	if (mainGetStageNum() != STAGE_ATTACKSHIP
 			&& mainGetStageNum() != STAGE_SKEDARRUINS
 			&& index >= WEAPON_SLAYER) {
 		index++;
 	}
+#endif
 
 #if (VERSION >= VERSION_JPN_FINAL) && defined(PLATFORM_N64)
 	if (index >= 26) {
@@ -299,9 +301,11 @@ s32 currentStageForbidsSlayer(void)
 {
 	bool value = VERSION >= VERSION_JPN_FINAL ? 1 : 0;
 
+#ifdef PLATFORM_N64
 	if (mainGetStageNum() != STAGE_ATTACKSHIP && mainGetStageNum() != STAGE_SKEDARRUINS) {
 		value++;
 	}
+#endif
 
 	return value;
 }
@@ -316,9 +320,11 @@ bool invCanHaveAllGunsWeapon(s32 weaponnum)
 	}
 #endif
 
+#ifdef PLATFORM_N64
 	if (weaponnum == WEAPON_SLAYER) {
 		canhave = false;
 	}
+#endif
 
 	// @bug: The stage conditions need an OR. This condition can never pass.
 	if ((mainGetStageNum() == STAGE_ATTACKSHIP && mainGetStageNum() == STAGE_SKEDARRUINS)

--- a/src/game/player.c
+++ b/src/game/player.c
@@ -3470,6 +3470,7 @@ void playerTick(bool arg0)
 
 			bgFindRoomsByPos(&rocketpos, inrooms, aboverooms, 20, &bestroom);
 
+#ifdef PLATFORM_N64
 			if (inrooms[0] == -1) {
 				outofbounds = true;
 			}
@@ -3494,6 +3495,7 @@ void playerTick(bool arg0)
 					g_Vars.currentplayer->badrockettime = 0;
 				}
 			}
+#endif
 
 			mtx00016208(sp2b8, &sp2f0);
 			mtx00016208(sp2b8, &sp2e4);


### PR DESCRIPTION
No exploding when going out of bounds, allows for more exploration, such as the intro sequence area in the first level (just launch a rocket when facing the dD logo and head towards the black void)

https://github.com/fgsfdsfgs/perfect_dark/assets/1617767/cd8240e3-f320-4787-96f4-fbbce06faaeb

Works especially well with the change to add Slayer to the "All Guns" cheat: https://github.com/fgsfdsfgs/perfect_dark/pull/442 which is what the first commit contains

This allows for exploration of all levels.

This is draft because I just want to gauge interest in this change. If other folks would like this, maybe it should either be a cheat or a setting since the default behavior of the games makes sense from a gameplay standpoint and should remain. If not, I'm happy to close this PR as well. What would be close IMO would be to make rockets not explode when they collide with a wall either, basically never explode unless pressing the Z button. If there's interested, I can look into that.