### PR TITLE
Allow users to set up more than one Laptop Gun sentry

### DIFF
--- a/src/game/propobj.c
+++ b/src/game/propobj.c
@@ -134,6 +134,7 @@ s32 g_LastPadEffectIndex = -1;
 struct autogunobj *g_ThrownLaptops = NULL;
 struct beam *g_ThrownLaptopBeams = NULL;
 s32 g_MaxThrownLaptops = 0;
+s32 g_MaxThrownLaptopsPerPlayer = 1000;
 
 /**
  * Attempt to call a lift from the given door.
@@ -18471,7 +18472,12 @@ struct autogunobj *laptopDeploy(s32 modelnum, struct gset *gset, struct chrdata 
 	if (index >= 0 && index < g_MaxThrownLaptops) {
 		setupLoadModeldef(modelnum);
 		modeldef = g_ModelStates[modelnum].modeldef;
-		laptop = &g_ThrownLaptops[index];
+		s32 laptopIndex = index * g_MaxThrownLaptopsPerPlayer;
+
+		do {
+			laptop = &g_ThrownLaptops[laptopIndex];
+			laptopIndex++;
+		} while (laptop->base.prop);
 
 		if (laptop->base.prop) {
 #if VERSION >= VERSION_NTSC_1_0

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -297,7 +297,7 @@ void propsReset(void)
 	g_AutogunDamageRxScale = 1;
 	g_AmmoQuantityScale = 1;
 
-	g_MaxThrownLaptops = g_Vars.normmplayerisrunning ? 12 : PLAYERCOUNT();
+	g_MaxThrownLaptops = (g_Vars.normmplayerisrunning ? 12 : PLAYERCOUNT()) * g_MaxThrownLaptopsPerPlayer;
 
 	g_ThrownLaptops = mempAlloc(ALIGN16(g_MaxThrownLaptops * sizeof(struct autogunobj)), MEMPOOL_STAGE);
 	g_ThrownLaptopBeams = mempAlloc(ALIGN16(g_MaxThrownLaptops * sizeof(struct beam)), MEMPOOL_STAGE);

--- a/src/include/data.h
+++ b/src/include/data.h
@@ -225,6 +225,7 @@ extern s32 g_LastPadEffectIndex;
 extern struct autogunobj *g_ThrownLaptops;
 extern struct beam *g_ThrownLaptopBeams;
 extern s32 g_MaxThrownLaptops;
+extern s32 g_MaxThrownLaptopsPerPlayer;
 extern struct prop *g_Lifts[10];
 extern u32 g_TvCmdlist00[];
 extern u32 var8006aaa0[];


### PR DESCRIPTION
Here's a draft PR to allows users to set up up to 1000 sentry guns instead of just one. This can be fun in multiplayer, where you can have a level covered with sentries everywhere.

This is a draft PR just to gauge interest. If this is something we'd want, this would likely need to be a setting somewhere, or potentially a cheat. I'm not sure how that would work since the game allocates memory for a certain number of sentries, so I don't know how to make that dynamic yet but I can spend a bit of time and figure that out if there's interest.

As it currently is, this game works well most of the time but the game does crash sometimes.

![Screenshot 2023-11-20 002111](https://github.com/fgsfdsfgs/perfect_dark/assets/1617767/d33d824e-625d-4793-9d03-5f9f39229223)

![Screenshot 2023-11-24 185652](https://github.com/fgsfdsfgs/perfect_dark/assets/1617767/45f35186-03d4-43fd-8d00-e560ab88d836)
