### PR TITLE
Give Cloaking Device at respawn if cheat is active

### DIFF
--- a/src/game/player.c
+++ b/src/game/player.c
@@ -1100,6 +1100,15 @@ void playerSpawn(void)
 			}
 		} else {
 #ifndef PLATFORM_N64
+			if (cheatIsActive(CHEAT_CLOAKINGDEVICE)) {
+				invGiveSingleWeapon(WEAPON_CLOAKINGDEVICE);
+#if VERSION >= VERSION_PAL_FINAL
+				bgunSetAmmoQuantity(AMMOTYPE_CLOAK, TICKS(7200));
+#else
+				bgunSetAmmoQuantity(AMMOTYPE_CLOAK, 7200);
+#endif
+			}
+
 			if (cheatIsActive(CHEAT_PERFECTDARKNESS)) {
 				invGiveSingleWeapon(WEAPON_NIGHTVISION);
 			}


### PR DESCRIPTION
Similar to the Night Vision one at https://github.com/fgsfdsfgs/perfect_dark/pull/406

If you have the cheat active and die, then you get the Cloaking Device again on respawn.