### PR TITLE
Depth compare improvements based on GlideN64

### DIFF
--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -1245,7 +1245,8 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
         rendering_state.depth_zfar = rsp.depth_zfar;
     }
 
-    bool depth_test = (rsp.geometry_mode & G_ZBUFFER) == G_ZBUFFER;
+    bool depth_test = ((rsp.geometry_mode & G_ZBUFFER) == G_ZBUFFER || (rdp.other_mode_l & G_ZS_PRIM) == G_ZS_PRIM) &&
+                      ((rdp.other_mode_h & G_CYC_1CYCLE) == G_CYC_1CYCLE || (rdp.other_mode_h & G_CYC_2CYCLE) == G_CYC_2CYCLE);
     bool depth_update = (rdp.other_mode_l & Z_UPD) == Z_UPD;
     bool depth_compare = (rdp.other_mode_l & Z_CMP) == Z_CMP;
     bool depth_source_prim = (rdp.other_mode_l & G_ZS_PRIM) == G_ZS_PRIM /* && gDP.primDepth.z == 1.0f */;

--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -197,9 +197,8 @@ static struct RDP {
 } rdp;
 
 static struct RenderingState {
-    uint8_t depth_test_and_mask; // 1: depth test, 2: depth mask
+    uint8_t depth_mode;
     float depth_zfar;
-    bool decal_mode;
     bool alpha_blend;
     bool modulate;
     struct XYWidthHeight viewport, scissor;
@@ -1240,25 +1239,23 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
         }
     }
 
-    bool depth_test = (rsp.geometry_mode & G_ZBUFFER) == G_ZBUFFER;
-    bool depth_mask = (rdp.other_mode_l & Z_UPD) == Z_UPD;
-    uint8_t depth_test_and_mask = (depth_test ? 1 : 0) | (depth_mask ? 2 : 0);
-    if (depth_test_and_mask != rendering_state.depth_test_and_mask) {
-        gfx_flush();
-        gfx_rapi->set_depth_test_and_mask(depth_test, depth_mask);
-        rendering_state.depth_test_and_mask = depth_test_and_mask;
-    }
     if (rsp.depth_zfar != rendering_state.depth_zfar) {
         gfx_flush();
         gfx_rapi->set_depth_range(0.0f, rsp.depth_zfar);
         rendering_state.depth_zfar = rsp.depth_zfar;
     }
 
-    bool zmode_decal = (rdp.other_mode_l & ZMODE_DEC) == ZMODE_DEC;
-    if (zmode_decal != rendering_state.decal_mode) {
+    bool depth_test = (rsp.geometry_mode & G_ZBUFFER) == G_ZBUFFER;
+    bool depth_update = (rdp.other_mode_l & Z_UPD) == Z_UPD;
+    bool depth_compare = (rdp.other_mode_l & Z_CMP) == Z_CMP;
+    bool depth_source_prim = (rdp.other_mode_l & G_ZS_PRIM) == G_ZS_PRIM /* && gDP.primDepth.z == 1.0f */;
+    uint16_t zmode = rdp.other_mode_l & ZMODE_DEC;
+    uint8_t depth_mode = (depth_test ? 1 : 0) | (depth_update ? 2 : 0) | (depth_compare ? 4 : 0) | (depth_source_prim ? 8 : 0) | (zmode >> 6);
+
+    if (depth_mode != rendering_state.depth_mode) {
         gfx_flush();
-        gfx_rapi->set_zmode_decal(zmode_decal);
-        rendering_state.decal_mode = zmode_decal;
+        gfx_rapi->set_depth_mode(depth_test, depth_update, depth_compare, depth_source_prim, zmode);
+        rendering_state.depth_mode = depth_mode;
     }
 
     if (rdp.viewport_or_scissor_changed) {

--- a/port/fast3d/gfx_rendering_api.h
+++ b/port/fast3d/gfx_rendering_api.h
@@ -27,9 +27,8 @@ struct GfxRenderingAPI {
     void (*select_texture)(int tile, uint32_t texture_id);
     void (*upload_texture)(const uint8_t* rgba32_buf, uint32_t width, uint32_t height);
     void (*set_sampler_parameters)(int sampler, bool linear_filter, uint32_t cms, uint32_t cmt);
-    void (*set_depth_test_and_mask)(bool depth_test, bool z_upd);
+    void (*set_depth_mode)(bool depth_test, bool depth_update, bool depth_compare, bool depth_source_prim, uint16_t zmode);
     void (*set_depth_range)(float znear, float zfar);
-    void (*set_zmode_decal)(bool zmode_decal);
     void (*set_viewport)(int x, int y, int width, int height);
     void (*set_scissor)(int x, int y, int width, int height);
     void (*set_use_alpha)(bool use_alpha, bool modulate);


### PR DESCRIPTION
After investigating the weapon clipping issue (https://github.com/fgsfdsfgs/perfect_dark/issues/18), I found out some other clipping issues that were caused due to a different reason: the port always uses `GL_LEQUAL` as depth compare function, but sometimes it should be `GL_LESS`.

The changes are based on GlideN64. In theory it should be more correct now in general, and didn't see anything broken yet.

Some comparisons (the weapon is still broken):

![PD_Depth](https://github.com/user-attachments/assets/e7323f89-a4ad-4fcc-862c-181de77a4264)
![PD_Depth_2](https://github.com/user-attachments/assets/aa73d9ba-58cf-4c57-b967-8f033d3998e2)
