### PR TITLE
Implemented depth clear, and disabled some depth range functionality

### DIFF
--- a/port/fast3d/gfx_opengl.cpp
+++ b/port/fast3d/gfx_opengl.cpp
@@ -1065,12 +1065,23 @@ bool gfx_opengl_start_draw_to_framebuffer(int fb_id, float noise_scale) {
     }
 }
 
-void gfx_opengl_clear_framebuffer() {
+void gfx_opengl_clear_framebuffer(bool clear_color, bool clear_depth) {
     glDisable(GL_SCISSOR_TEST);
-    glDepthMask(GL_TRUE);
-    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    glDepthMask(current_depth_mask ? GL_TRUE : GL_FALSE);
+    
+    GLbitfield mask = 0;
+    if (clear_color) {
+        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        mask |= GL_COLOR_BUFFER_BIT;
+    }
+    if (clear_depth) {
+        glDepthMask(GL_TRUE);
+        mask |= GL_DEPTH_BUFFER_BIT;
+    }
+    glClear(mask);
+    if (clear_depth) {
+        glDepthMask(current_depth_mask ? GL_TRUE : GL_FALSE);
+    }
+
     glEnable(GL_SCISSOR_TEST);
 }
 

--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -125,7 +125,7 @@ static struct RSP {
     float aspect_ofs;
     float aspect_scale;
 
-    float depth_zfar;
+    //float depth_zfar;
 
     struct {
         // U0.16
@@ -198,7 +198,7 @@ static struct RDP {
 
 static struct RenderingState {
     uint8_t depth_mode;
-    float depth_zfar;
+    //float depth_zfar;
     bool alpha_blend;
     bool modulate;
     struct XYWidthHeight viewport, scissor;
@@ -1239,11 +1239,11 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
         }
     }
 
-    if (rsp.depth_zfar != rendering_state.depth_zfar) {
-        gfx_flush();
-        gfx_rapi->set_depth_range(0.0f, rsp.depth_zfar);
-        rendering_state.depth_zfar = rsp.depth_zfar;
-    }
+    // if (rsp.depth_zfar != rendering_state.depth_zfar) {
+    //     gfx_flush();
+    //     gfx_rapi->set_depth_range(0.0f, rsp.depth_zfar);
+    //     rendering_state.depth_zfar = rsp.depth_zfar;
+    // }
 
     bool depth_test = ((rsp.geometry_mode & G_ZBUFFER) == G_ZBUFFER || (rdp.other_mode_l & G_ZS_PRIM) == G_ZS_PRIM) &&
                       ((rdp.other_mode_h & G_CYC_1CYCLE) == G_CYC_1CYCLE || (rdp.other_mode_h & G_CYC_2CYCLE) == G_CYC_2CYCLE);
@@ -1735,13 +1735,13 @@ static void gfx_sp_moveword(uint8_t index, uint16_t offset, uintptr_t data) {
             // the default z range is around [100, 10000]
             // data is 2 / (znear + zfar) represented as a 0.16 fixed point
             // => (znear + zfar) = (2 / (data / 65536)) = 131072 / data
-            constexpr float full_range_mul = 1.f / 11000.f; // that's around the biggest value I got when testing
-            if (data == 0) {
-                rsp.depth_zfar = 1.f;
-            } else {
-                // sometimes this will overshoot 1 but GL can handle that
-                rsp.depth_zfar =((131072.f * full_range_mul) / (float)data);
-            }
+            // constexpr float full_range_mul = 1.f / 11000.f; // that's around the biggest value I got when testing
+            // if (data == 0) {
+            //     rsp.depth_zfar = 1.f;
+            // } else {
+            //     // sometimes this will overshoot 1 but GL can handle that
+            //     rsp.depth_zfar =((131072.f * full_range_mul) / (float)data);
+            // }
             break;
     }
 }
@@ -2556,7 +2556,7 @@ extern "C" void gfx_init(const GfxInitSettings *settings) {
         tex_upload_buffer = (uint8_t*)malloc(max_tex_size * max_tex_size * 4);
     }
 
-    rsp.depth_zfar = 1.0f;
+    //rsp.depth_zfar = 1.0f;
 
     rsp.lookat[0].dir[0] = rsp.lookat[1].dir[1] = 0x7F;
     rsp.current_lookat_coeffs[0][0] = rsp.current_lookat_coeffs[1][1] = 1.f;

--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -2502,6 +2502,10 @@ static void gfx_run_dl(Gfx* cmd) {
             case G_RDPFLUSH_EXT:
                 gfx_flush();
                 break;
+            case G_CLEAR_DEPTH_EXT:
+                gfx_flush();
+                gfx_rapi->clear_framebuffer(false, true);
+                break;
             case G_RDPPIPESYNC:
             case G_RDPFULLSYNC:
             case G_RDPLOADSYNC:
@@ -2659,7 +2663,7 @@ extern "C" void gfx_run(Gfx* commands) {
     gfx_rapi->start_frame();
     gfx_rapi->start_draw_to_framebuffer(game_renders_to_framebuffer ? game_framebuffer : 0,
                                         (float)gfx_current_dimensions.height / SCREEN_HEIGHT);
-    gfx_rapi->clear_framebuffer();
+    gfx_rapi->clear_framebuffer(true, false);
     rdp.viewport_or_scissor_changed = true;
     rendering_state.viewport = {};
     rendering_state.scissor = {};
@@ -2669,7 +2673,7 @@ extern "C" void gfx_run(Gfx* commands) {
 
     if (game_renders_to_framebuffer) {
         gfx_rapi->start_draw_to_framebuffer(0, 1);
-        gfx_rapi->clear_framebuffer();
+        gfx_rapi->clear_framebuffer(true, true);
 
         if (gfx_msaa_level > 1) {
             bool different_size = gfx_current_dimensions.width != gfx_current_game_window_viewport.width ||
@@ -2732,7 +2736,7 @@ extern "C" void gfx_resize_framebuffer(int fb, uint32_t width, uint32_t height, 
 
 extern "C" void gfx_set_framebuffer(int fb, float noise_scale) {
     gfx_rapi->start_draw_to_framebuffer(fb, noise_scale);
-    gfx_rapi->clear_framebuffer();
+    gfx_rapi->clear_framebuffer(true, true);
 }
 
 extern "C" void gfx_copy_framebuffer(int fb_dst, int fb_src, int left, int top, int use_back) {

--- a/port/fast3d/gfx_rendering_api.h
+++ b/port/fast3d/gfx_rendering_api.h
@@ -44,7 +44,7 @@ struct GfxRenderingAPI {
                                           bool can_extract_depth);
     bool (*start_draw_to_framebuffer)(int fb_id, float noise_scale);
     void (*copy_framebuffer)(int fb_dst, int fb_src, int left, int top, bool flip_y, bool use_back);
-    void (*clear_framebuffer)(void);
+    void (*clear_framebuffer)(bool clear_color, bool clear_depth);
     void (*resolve_msaa_color_buffer)(int fb_id_target, int fb_id_source);
     void* (*get_framebuffer_texture_id)(int fb_id);
     void (*select_texture_fb)(int fb_id);

--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -10933,7 +10933,6 @@ void bgunRender(Gfx **gdlptr)
 	struct modelrenderdata renderdata = {NULL, true, 3}; // 10c
 	struct player *player;
 	s32 i;
-	const u32 wnorm = mtx00016dcc(0, 300);
 
 	static bool renderhand = true; // var800702dc
 
@@ -10999,7 +10998,7 @@ void bgunRender(Gfx **gdlptr)
 				gSPLookAt(gdl++, camGetLookAt());
 			}
 
-			gSPPerspNormalize(gdl++, wnorm);
+			gSPPerspNormalize(gdl++, mtx00016dcc(0, 300));
 
 			// There is support for guns having a TV screen on them
 			// but no guns have this model part so it's not used.
@@ -11174,17 +11173,7 @@ void bgunRender(Gfx **gdlptr)
 		}
 	}
 
-#ifndef PLATFORM_N64
-	// put the casings into the same Z range as the gun
-	gSPPerspNormalize(gdl++, wnorm);
-#endif
-
 	casingsRender(&gdl);
-
-#ifndef PLATFORM_N64
-	gSPPerspNormalize(gdl++, viGetPerspScale());
-#endif
-
 	zbufSwap();
 
 	gdl = zbufConfigureRdp(gdl);

--- a/src/game/zbuf.c
+++ b/src/game/zbuf.c
@@ -126,7 +126,6 @@ Gfx *zbufConfigureRdp(Gfx *gdl)
 Gfx *zbufClear(Gfx *gdl)
 {
 #ifdef PLATFORM_N64
-	// no reason to do a Z clear on PC, we already do it at frame start
 	s32 left;
 	s32 right;
 
@@ -150,6 +149,8 @@ Gfx *zbufClear(Gfx *gdl)
 
 	gDPFillRectangle(gdl++, left, 0, right, playerGetFbHeight() - 1);
 	gDPPipeSync(gdl++);
+#else
+	gDPClearDepthEXT(gdl++);
 #endif
 
 	return gdl;

--- a/src/include/gbiex.h
+++ b/src/include/gbiex.h
@@ -195,6 +195,7 @@
 #define G_COPYFB_EXT            0x41
 #define G_IMAGERECT_EXT         0x42
 #define G_RDPFLUSH_EXT          0x43
+#define G_CLEAR_DEPTH_EXT       0x44
 
 /* G_EXTRAGEOMETRYMODE flags */
 
@@ -299,6 +300,8 @@
 #define gSPTextureRectangleFlipEXT(p, xl, yl, xh, yh, tile, s, t, ds, dt) gSPTextureRectangleWideEXT(p, xl, yl, xh, yh, tile, s, t, ds, dt, G_ON)
 
 #define gDPFlushEXT(pkt) gDPNoParam(pkt, G_RDPFLUSH_EXT)
+
+#define gDPClearDepthEXT(pkt) gDPNoParam(pkt, G_CLEAR_DEPTH_EXT)
 
 #undef gDPFillRectangleScaled
 #define gDPFillRectangleScaled(pkt, x1, y1, x2, y2) gDPFillRectangleEXT(pkt, (x1) * g_ScaleX, y1, (x2) * g_ScaleX, y2)


### PR DESCRIPTION
As the title says. This fixes weapon clipping issue in some levels (https://github.com/fgsfdsfgs/perfect_dark/issues/18), making some depth range functionality not needed anymore apparently. So I disabled that. Haven't noticed any side effects and it also works on split screen multiplayer.

![PD_Depth_3](https://github.com/user-attachments/assets/19c61cee-3fd0-4510-ba0c-4239c6f274ee)
