### PR TITLE
Three point mode and shader fixes 

### DIFF
--- a/port/src/video.c
+++ b/port/src/video.c
@@ -218,6 +218,7 @@ void videoSetMaximizeWindow(s32 fs)
 void videoSetTextureFilter(u32 filter)
 {
 	if (filter > FILTER_THREE_POINT) filter = FILTER_THREE_POINT;
+	if (texFilter == filter) return;
 	texFilter = filter;
 	gfx_set_texture_filter((enum FilteringMode)filter);
 }


### PR DESCRIPTION
Turns out we both worked at the same time on clearing the shader pool properly in order to not have three point shader code when not necessary. We basically did the same thing, with the exception of me not clearing the color combiner pool, as that wasn't necessary in my implementation, only the shader pool and the current program in the render state. We both even added the `glDeleteShader` calls.

So I discarded most of my stuff and this PR contains some fixes that were in my implementation:

- Don't perform a filter mode change if the new mode is the same as the previous one.
- Fixed blurry menu background being unfiltered when three point is enabled.
- `glDeleteShader` doesn't do anything unless detaching the shader first.
- Some shader code refactor:
  - Further remove some three point stuff when not needed, like the parameter in `hookTexture2D`.
  - Reduce the amount of `__APPLE__` defines: use the SAMPLE_TEX macro to sample textures.