### PR TITLE
Fixed viewport calculations for models in menus, and other menu fixes

### DIFF
--- a/src/game/menu.c
+++ b/src/game/menu.c
@@ -2262,7 +2262,21 @@ Gfx *menuRenderModel(Gfx *gdl, struct menumodel *menumodel, s32 modeltype)
 				gdl = func0f0d49c8(gdl);
 				gSPMatrix(gdl++, osVirtualToPhysical(camGetPerspectiveMtxL()), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
 			} else {
-				f32 aspect = (f32) (g_MenuScissorX2 - g_MenuScissorX1) / (f32) (g_MenuScissorY2 - g_MenuScissorY1);
+#ifdef PLATFORM_N64
+				s32 x1 = g_MenuScissorX1;
+				s32 x2 = g_MenuScissorX2;
+#else
+				s32 halfScreenWidth = SCREEN_WIDTH_LO >> 1;
+				f32 scale = SCREEN_ASPECT / videoGetAspect();
+				f32 width = (g_MenuScissorX2 - g_MenuScissorX1) * scale;
+				f32 center = (g_MenuScissorX1 + g_MenuScissorX2) * 0.5f;
+				center = ((center - halfScreenWidth) * scale) + halfScreenWidth;
+
+				s32 x1 = (s32)(center - width * 0.5f);
+				s32 x2 = (s32)(center + width * 0.5f);
+#endif
+
+				f32 aspect = (f32) (x2 - x1) / (f32) (g_MenuScissorY2 - g_MenuScissorY1);
 
 				static u32 znear = 10;
 				static u32 zfar = 300;
@@ -2272,8 +2286,8 @@ Gfx *menuRenderModel(Gfx *gdl, struct menumodel *menumodel, s32 modeltype)
 
 				gdl = func0f0d49c8(gdl);
 
-				viSetViewPosition(g_MenuScissorX1 * g_ScaleX, g_MenuScissorY1);
-				viSetFovAspectAndSize(g_Vars.currentplayer->fovy, aspect, (g_MenuScissorX2 - g_MenuScissorX1) * g_ScaleX, g_MenuScissorY2 - g_MenuScissorY1);
+				viSetViewPosition(x1 * g_ScaleX, g_MenuScissorY1);
+				viSetFovAspectAndSize(g_Vars.currentplayer->fovy, aspect, (x2 - x1) * g_ScaleX, g_MenuScissorY2 - g_MenuScissorY1);
 
 				gdl = vi0000af00(gdl, var800a2048[g_MpPlayerNum]);
 				gdl = vi0000aca4(gdl, znear, zfar);

--- a/src/game/menuitem.c
+++ b/src/game/menuitem.c
@@ -2607,11 +2607,17 @@ Gfx *menuitemCarouselRender(Gfx *gdl, struct menurendercontext *context)
 		colour = colourBlend(colourBlend(colour, 0x000000ff, 127), colour1, weight);
 	}
 
+#ifdef PLATFORM_N64
+	s16 chevronOffset = 0;
+#else 
+	s16 chevronOffset = 3;
+#endif
+
 	// Left arrow
-	gdl = menugfxDrawCarouselChevron(gdl, context->x, context->y + context->height / 2, 8, 1, -1, colour);
+	gdl = menugfxDrawCarouselChevron(gdl, context->x + chevronOffset, context->y + context->height / 2, 8, 1, -1, colour);
 
 	// Right arrow
-	gdl = menugfxDrawCarouselChevron(gdl, context->x + context->width, context->y + context->height / 2, 8, 3, -1, colour);
+	gdl = menugfxDrawCarouselChevron(gdl, context->x + context->width - chevronOffset, context->y + context->height / 2, 8, 3, -1, colour);
 
 	// This part of the function is unused because param2 is always zero.
 	// Setting it to 0x7b causes a crash.

--- a/src/game/trainingmenus.c
+++ b/src/game/trainingmenus.c
@@ -1535,19 +1535,7 @@ MenuDialogHandlerResult ciCharacterProfileMenuDialog(s32 operation, struct menud
 	f32 y;
 	f32 scale;
 
-	switch (operation) {
-	case MENUOP_OPEN:
-		if (bodynum == BODY_DRCAROLL) {
-			scale = 0.7f;
-			g_Menus[g_MpPlayerNum].menumodel.zoom = -1;
-		} else {
-			g_Menus[g_MpPlayerNum].menumodel.zoom = 30;
-			scale = 1.0f;
-		}
-
-		g_Menus[g_MpPlayerNum].menumodel.zoomtimer60 = TICKS(120);
-		g_Menus[g_MpPlayerNum].menumodel.removingpiece = false;
-
+#ifndef PLATFORM_N64
 #if VERSION == VERSION_PAL_FINAL
 		if (g_ViRes != VIRES_HI) {
 			x = -117;
@@ -1574,6 +1562,50 @@ MenuDialogHandlerResult ciCharacterProfileMenuDialog(s32 operation, struct menud
 		if (optionsGetScreenRatio() == SCREENRATIO_16_9) {
 			x = -100;
 		}
+#endif
+#endif
+
+	switch (operation) {
+	case MENUOP_OPEN:
+		if (bodynum == BODY_DRCAROLL) {
+			scale = 0.7f;
+			g_Menus[g_MpPlayerNum].menumodel.zoom = -1;
+		} else {
+			g_Menus[g_MpPlayerNum].menumodel.zoom = 30;
+			scale = 1.0f;
+		}
+
+		g_Menus[g_MpPlayerNum].menumodel.zoomtimer60 = TICKS(120);
+		g_Menus[g_MpPlayerNum].menumodel.removingpiece = false;
+
+#ifdef PLATFORM_N64
+#if VERSION == VERSION_PAL_FINAL
+		if (g_ViRes != VIRES_HI) {
+			x = -117;
+
+			if (optionsGetScreenRatio() == SCREENRATIO_16_9) {
+				x = -87;
+			}
+		} else {
+			x = -177;
+
+			if (optionsGetScreenRatio() == SCREENRATIO_16_9) {
+				x = -127;
+			}
+		}
+#elif VERSION == VERSION_PAL_BETA
+		x = -117;
+
+		if (optionsGetScreenRatio() == SCREENRATIO_16_9) {
+			x = -87;
+		}
+#else
+		x = -130;
+
+		if (optionsGetScreenRatio() == SCREENRATIO_16_9) {
+			x = -100;
+		}
+#endif
 #endif
 
 		y = -15;
@@ -1603,6 +1635,11 @@ MenuDialogHandlerResult ciCharacterProfileMenuDialog(s32 operation, struct menud
 	case MENUOP_CLOSE:
 		break;
 	case MENUOP_TICK:
+#ifndef PLATFORM_N64
+		x = (float)x * ((f32)SCREEN_WIDTH_LO / (f32)SCREEN_HEIGHT_LO) / videoGetAspect();
+		g_Menus[g_MpPlayerNum].menumodel.newposx = x;
+#endif
+
 		if (bodynum == BODY_DRCAROLL) {
 			static struct modelpartvisibility vis[] = {
 				{ MODELPART_DRCAROLL_0001, false },

--- a/src/game/trainingmenus.c
+++ b/src/game/trainingmenus.c
@@ -1888,6 +1888,7 @@ MenuDialogHandlerResult dtTrainingDetailsMenuDialog(s32 operation, struct menudi
 			g_Menus[g_MpPlayerNum].training.weaponnum = weaponnum;
 			func0f105948(weaponnum);
 
+#ifdef PLATFORM_N64
 #if VERSION == VERSION_PAL_FINAL
 			if (g_ViRes == VIRES_HI) {
 				if (optionsGetScreenRatio() == SCREENRATIO_16_9) {
@@ -1923,6 +1924,7 @@ MenuDialogHandlerResult dtTrainingDetailsMenuDialog(s32 operation, struct menudi
 				g_Menus[g_MpPlayerNum].menumodel.curposx = 90;
 			}
 #endif
+#endif
 
 #ifndef PLATFORM_N64
 			g_Menus[g_MpPlayerNum].menumodel.newposx *= ((f32)SCREEN_WIDTH_LO / (f32)SCREEN_HEIGHT_LO) / videoGetAspect();
@@ -1935,6 +1937,47 @@ MenuDialogHandlerResult dtTrainingDetailsMenuDialog(s32 operation, struct menudi
 	case MENUOP_CLOSE:
 		break;
 	case MENUOP_TICK:
+#ifndef PLATFORM_N64
+#if VERSION == VERSION_PAL_FINAL
+		if (g_ViRes == VIRES_HI) {
+			if (optionsGetScreenRatio() == SCREENRATIO_16_9) {
+				g_Menus[g_MpPlayerNum].menumodel.newposx = 84;
+				g_Menus[g_MpPlayerNum].menumodel.curposx = 84;
+			} else {
+				g_Menus[g_MpPlayerNum].menumodel.newposx = 104;
+				g_Menus[g_MpPlayerNum].menumodel.curposx = 104;
+			}
+		} else {
+			if (optionsGetScreenRatio() == SCREENRATIO_16_9) {
+				g_Menus[g_MpPlayerNum].menumodel.newposx = 64;
+				g_Menus[g_MpPlayerNum].menumodel.curposx = 64;
+			} else {
+				g_Menus[g_MpPlayerNum].menumodel.newposx = 84;
+				g_Menus[g_MpPlayerNum].menumodel.curposx = 84;
+			}
+		}
+#elif VERSION == VERSION_PAL_BETA
+		if (optionsGetScreenRatio() == SCREENRATIO_16_9) {
+			g_Menus[g_MpPlayerNum].menumodel.newposx = 64;
+			g_Menus[g_MpPlayerNum].menumodel.curposx = 64;
+		} else {
+			g_Menus[g_MpPlayerNum].menumodel.newposx = 84;
+			g_Menus[g_MpPlayerNum].menumodel.curposx = 84;
+		}
+#else
+		if (optionsGetScreenRatio() == SCREENRATIO_16_9) {
+			g_Menus[g_MpPlayerNum].menumodel.newposx = 70;
+			g_Menus[g_MpPlayerNum].menumodel.curposx = 70;
+		} else {
+			g_Menus[g_MpPlayerNum].menumodel.newposx = 90;
+			g_Menus[g_MpPlayerNum].menumodel.curposx = 90;
+		}
+#endif
+
+		g_Menus[g_MpPlayerNum].menumodel.newposx *= ((f32)SCREEN_WIDTH_LO / (f32)SCREEN_HEIGHT_LO) / videoGetAspect();
+		g_Menus[g_MpPlayerNum].menumodel.curposx = g_Menus[g_MpPlayerNum].menumodel.newposx;
+#endif
+
 		if (g_Menus[g_MpPlayerNum].curdialog && g_Menus[g_MpPlayerNum].curdialog->definition == dialogdef) {
 			if (dtGetWeaponByDeviceIndex(dtGetIndexBySlot(g_DtSlot)) == WEAPON_DISGUISE41) {
 				g_Menus[g_MpPlayerNum].menumodel.newanimnum = ANIM_006A;

--- a/src/game/trainingmenus.c
+++ b/src/game/trainingmenus.c
@@ -1926,11 +1926,6 @@ MenuDialogHandlerResult dtTrainingDetailsMenuDialog(s32 operation, struct menudi
 #endif
 #endif
 
-#ifndef PLATFORM_N64
-			g_Menus[g_MpPlayerNum].menumodel.newposx *= ((f32)SCREEN_WIDTH_LO / (f32)SCREEN_HEIGHT_LO) / videoGetAspect();
-			g_Menus[g_MpPlayerNum].menumodel.curposx = g_Menus[g_MpPlayerNum].menumodel.newposx;
-#endif
-
 			g_Menus[g_MpPlayerNum].menumodel.newscale /= 2.5f;
 		}
 		break;

--- a/src/game/trainingmenus.c
+++ b/src/game/trainingmenus.c
@@ -1924,6 +1924,11 @@ MenuDialogHandlerResult dtTrainingDetailsMenuDialog(s32 operation, struct menudi
 			}
 #endif
 
+#ifndef PLATFORM_N64
+			g_Menus[g_MpPlayerNum].menumodel.newposx *= ((f32)SCREEN_WIDTH_LO / (f32)SCREEN_HEIGHT_LO) / videoGetAspect();
+			g_Menus[g_MpPlayerNum].menumodel.curposx = g_Menus[g_MpPlayerNum].menumodel.newposx;
+#endif
+
 			g_Menus[g_MpPlayerNum].menumodel.newscale /= 2.5f;
 		}
 		break;


### PR DESCRIPTION
- The size and position of the viewport in every menu was calculated wrongly. This usually didn't cause issues due to most menus being centered on the screen. But viewport would not fit the size of the menu window depending on the game's resolution. This was noticeable in the character selection in multiplayer menus, as those are not centered.
- Fixed small N64 bug: the red arrows in the character and simulant selection menus were a bit cropped due to the scissor. Now they are a bit more inside the menu window.
- Fixed wrong position of the model in the device training menu, that would offset base on the game's resolution. Also, the position is recalculated every tick so it doesn't break when resizing the game's window while that training menu is open.
- Position is now recalculated every tick too in the character profiles menu.

This fixes this issue, maybe others: https://github.com/fgsfdsfgs/perfect_dark/issues/427

![PD0](https://github.com/user-attachments/assets/1a7ee131-4c9c-4c1a-9f26-ca6896798bb8)
![PD1](https://github.com/user-attachments/assets/552e823f-0616-4442-bb93-ad81daa2b8f9)
