### PR TITLE
Check GameBoy Color ROM to emulate Transfer Pak

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ There are minor graphics- and gameplay-related issues, and possibly occasional c
 * experimental high framerate support (up to 240 FPS):
   * set `Game.TickRateDivisor` to `0` in `pd.ini` to activate;
   * in practice the game will have issues running faster than ~165 FPS, so use VSync or `Video.FramerateLimit` to cap it.
+* emulate the Transfer Pak functionality the game has on the Nintendo 64 to unlock some cheats automatically.
 
 Currently only 32-bit platforms are supported, namely x86 Windows and Linux.  
 Note that 32-bit binaries will still work on 64-bit versions of those platforms,
@@ -57,6 +58,8 @@ You must already have a Perfect Dark ROM to run the game, as specified above.
 If you want to use a PAL or JPN ROM instead, put them into the `data` directory and run the appropriate executable:
 * PAL: ROM name `pd.pal-final.z64`, EXE name `pd.pal.exe`.
 * JPN: ROM name `pd.jpn-final.z64`, EXE name `pd.jpn.exe`.
+
+Optionally, you can also put your Perfect Dark for GameBoy Color ROM named `pd.gbc` in the `data` directory if you want to emulate having the Nintendo 64's Transfer Pak and unlock some cheats automatically.
 
 Additional information can be found in the [wiki](https://github.com/fgsfdsfgs/perfect_dark/wiki).
 

--- a/port/include/romdata.h
+++ b/port/include/romdata.h
@@ -22,4 +22,6 @@ u8 *romdataSegGetData(const char *segName);
 u8 *romdataSegGetDataEnd(const char *segName);
 u32 romdataSegGetSize(const char *segName);
 
+void gbcRomCheck(void);
+
 #endif

--- a/port/src/main.c
+++ b/port/src/main.c
@@ -107,6 +107,7 @@ int main(int argc, const char **argv)
 	inputInit();
 	audioInit();
 	romdataInit();
+	gbcRomCheck();
 
 	gameInit();
 

--- a/src/game/pak.c
+++ b/src/game/pak.c
@@ -329,6 +329,10 @@ u8 g_PaksPlugged = 0;
 bool var80075d14 = true;
 #endif
 
+#ifndef PLATFORM_N64
+bool g_validGbcRomFound = false;
+#endif
+
 u32 pakGetBlockSize(s8 device)
 {
 	return device == SAVEDEVICE_GAMEPAK ? 0x10 : 0x20;
@@ -5982,6 +5986,7 @@ s32 pak0f11e750(s8 device)
 
 bool gbpakIsAnyPerfectDark(void)
 {
+#ifdef PLATFORM_N64
 	s8 i;
 
 	for (i = 0; i < MAX_PLAYERS; i++) {
@@ -5991,6 +5996,9 @@ bool gbpakIsAnyPerfectDark(void)
 	}
 
 	return false;
+#else
+	return g_validGbcRomFound;
+#endif
 }
 
 /**

--- a/src/include/bss.h
+++ b/src/include/bss.h
@@ -293,5 +293,8 @@ extern struct bossfile g_BossFile;
 extern struct chrdata *g_MpBotChrPtrs[MAX_BOTS];
 extern s32 g_JpnMaxCacheItems;
 extern s32 var8009d370jf;
+#ifndef PLATFORM_N64
+extern bool g_validGbcRomFound;
+#endif
 
 #endif


### PR DESCRIPTION
This fixes this issue: https://github.com/fgsfdsfgs/perfect_dark/issues/496

Now you can put a Perfect Dark for GBC ROM named `pd.gbc` in the `data` folder to emulate having the Transfer Pak and unlock some cheats automatically.