### PR TITLE
Center-align crosshairs, zoom range, and radar

### DIFF
--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -1985,6 +1985,11 @@ static void gfx_draw_rectangle(int32_t ulx, int32_t uly, int32_t lrx, int32_t lr
         rdp.other_mode_h = (rdp.other_mode_h & ~(3U << G_MDSFT_TEXTFILT)) | G_TF_POINT;
     }
 
+    ulx += rdp.subpixel_ofs_x;
+    lrx += rdp.subpixel_ofs_x;
+    uly += rdp.subpixel_ofs_y;
+    lry += rdp.subpixel_ofs_y;
+
     // U10.2 coordinates
     float ulxf = ulx;
     float ulyf = uly;
@@ -2187,11 +2192,6 @@ static void gfx_dp_fill_rectangle(int32_t ulx, int32_t uly, int32_t lrx, int32_t
     if (mode == G_CYC_FILL) {
         gfx_dp_set_combine_mode(color_comb(0, 0, 0, G_CCMUX_SHADE), alpha_comb(0, 0, 0, G_ACMUX_SHADE), 0, 0);
     }
-
-    ulx += rdp.subpixel_ofs_x;
-    lrx += rdp.subpixel_ofs_x;
-    uly += rdp.subpixel_ofs_y;
-    lry += rdp.subpixel_ofs_y;
 
     gfx_draw_rectangle(ulx, uly, lrx, lry);
     rdp.combine_mode = saved_combine_mode;

--- a/src/game/bondview.c
+++ b/src/game/bondview.c
@@ -1109,14 +1109,14 @@ Gfx *bviewDrawEyespyMetrics(Gfx *gdl)
 		s32 x = viewleft + (viewwidth >> 1);
 		s32 y = viewtop + (viewheight >> 1);
 
-		gDPFillRectangle(gdl++, x + 2, y + 0, x + 7, y + 1);
-		gDPFillRectangle(gdl++, x + 2, y + 0, x + 5, y + 1);
-		gDPFillRectangle(gdl++, x - 6, y + 0, x - 1, y + 1);
-		gDPFillRectangle(gdl++, x - 4, y + 0, x - 1, y + 1);
-		gDPFillRectangle(gdl++, x + 0, y + 2, x + 1, y + 7);
-		gDPFillRectangle(gdl++, x + 0, y + 2, x + 1, y + 5);
-		gDPFillRectangle(gdl++, x + 0, y - 6, x + 1, y - 1);
-		gDPFillRectangle(gdl++, x + 0, y - 4, x + 1, y - 1);
+		gDPFillRectangleCenteredEXT(gdl++, x + 2, y + 0, x + 7, y + 1);
+		gDPFillRectangleCenteredEXT(gdl++, x + 2, y + 0, x + 5, y + 1);
+		gDPFillRectangleCenteredEXT(gdl++, x - 6, y + 0, x - 1, y + 1);
+		gDPFillRectangleCenteredEXT(gdl++, x - 4, y + 0, x - 1, y + 1);
+		gDPFillRectangleCenteredEXT(gdl++, x + 0, y + 2, x + 1, y + 7);
+		gDPFillRectangleCenteredEXT(gdl++, x + 0, y + 2, x + 1, y + 5);
+		gDPFillRectangleCenteredEXT(gdl++, x + 0, y - 6, x + 1, y - 1);
+		gDPFillRectangleCenteredEXT(gdl++, x + 0, y - 4, x + 1, y - 1);
 	}
 
 	if (g_Vars.currentplayer->eyespy->mode == EYESPYMODE_CAMSPY) {

--- a/src/game/bondview.c
+++ b/src/game/bondview.c
@@ -1109,14 +1109,22 @@ Gfx *bviewDrawEyespyMetrics(Gfx *gdl)
 		s32 x = viewleft + (viewwidth >> 1);
 		s32 y = viewtop + (viewheight >> 1);
 
-		gDPFillRectangleCenteredEXT(gdl++, x + 2, y + 0, x + 7, y + 1);
-		gDPFillRectangleCenteredEXT(gdl++, x + 2, y + 0, x + 5, y + 1);
-		gDPFillRectangleCenteredEXT(gdl++, x - 6, y + 0, x - 1, y + 1);
-		gDPFillRectangleCenteredEXT(gdl++, x - 4, y + 0, x - 1, y + 1);
-		gDPFillRectangleCenteredEXT(gdl++, x + 0, y + 2, x + 1, y + 7);
-		gDPFillRectangleCenteredEXT(gdl++, x + 0, y + 2, x + 1, y + 5);
-		gDPFillRectangleCenteredEXT(gdl++, x + 0, y - 6, x + 1, y - 1);
-		gDPFillRectangleCenteredEXT(gdl++, x + 0, y - 4, x + 1, y - 1);
+#ifndef PLATFORM_N64
+		gDPSetSubpixelOffsetEXT(gdl++, -2, -2);
+#endif
+
+		gDPFillRectangle(gdl++, x + 2, y + 0, x + 7, y + 1);
+		gDPFillRectangle(gdl++, x + 2, y + 0, x + 5, y + 1);
+		gDPFillRectangle(gdl++, x - 6, y + 0, x - 1, y + 1);
+		gDPFillRectangle(gdl++, x - 4, y + 0, x - 1, y + 1);
+		gDPFillRectangle(gdl++, x + 0, y + 2, x + 1, y + 7);
+		gDPFillRectangle(gdl++, x + 0, y + 2, x + 1, y + 5);
+		gDPFillRectangle(gdl++, x + 0, y - 6, x + 1, y - 1);
+		gDPFillRectangle(gdl++, x + 0, y - 4, x + 1, y - 1);
+
+#ifndef PLATFORM_N64
+		gDPSetSubpixelOffsetEXT(gdl++, 0, 0);
+#endif
 	}
 
 	if (g_Vars.currentplayer->eyespy->mode == EYESPYMODE_CAMSPY) {

--- a/src/game/radar.c
+++ b/src/game/radar.c
@@ -80,7 +80,7 @@ Gfx *radarRenderBackground(Gfx *gdl, struct textureconfig *tconfig, s32 arg2, s3
 
 	texSelect(&gdl, tconfig, 2, 0, 0, 1, NULL);
 	func0f0b278c(&gdl, spb0, spa8, tconfig->width, tconfig->height,
-			0, 0, 1, 0, 0xff, 0, 40, tconfig->level > 0, 0);
+			0, 0, 0, 0, 0xff, 0, 40, tconfig->level > 0, 0);
 
 	gDPPipeSync(gdl++);
 	gDPSetColorDither(gdl++, G_CD_BAYER);
@@ -329,6 +329,7 @@ Gfx *radarRender(Gfx *gdl)
 		}
 #ifndef PLATFORM_N64
 		gSPExtraGeometryModeEXT(gdl++, G_ASPECT_MODE_EXT, g_HudAlignModeR);
+		gDPSetSubpixelOffsetEXT(gdl++, -2, 2);
 #endif
 	}
 
@@ -337,6 +338,7 @@ Gfx *radarRender(Gfx *gdl)
 
 	// Draw dots for human players
 #ifndef PLATFORM_N64
+	gDPSetSubpixelOffsetEXT(gdl++, 0, 0);
 	if (!(g_MpSetup.options & MPOPTION_NOPLAYERONRADAR)) {
 #endif
 	for (i = 0; i < playercount; i++) {

--- a/src/game/sight.c
+++ b/src/game/sight.c
@@ -515,42 +515,44 @@ Gfx *sightDrawAimer(Gfx *gdl, s32 x, s32 y, s32 radius, s32 cornergap, u32 colou
 #ifndef PLATFORM_N64
 	x = sightGetAdjustedX(x);
 	gSPSetExtraGeometryModeEXT(gdl++, G_ASPECT_CENTER_EXT);
+	gDPSetSubpixelOffsetEXT(gdl++, -2, -2);
 #endif
 
 	// Draw the lines that span most of the viewport
 	if (PLAYERCOUNT() == 1) {
-		gDPHudRectangleCentered(gdl++, viewleft + 48, y, x - radius + 2, y);
-		gDPHudRectangleCentered(gdl++, x + radius - 2, y, viewright - 49, y);
-		gDPHudRectangleCentered(gdl++, x, viewtop + 10, x, y - radius + 2);
-		gDPHudRectangleCentered(gdl++, x, y + radius - 2, x, viewbottom - 10);
+		gDPHudRectangle(gdl++, viewleft + 48, y, x - radius + 2, y);
+		gDPHudRectangle(gdl++, x + radius - 2, y, viewright - 49, y);
+		gDPHudRectangle(gdl++, x, viewtop + 10, x, y - radius + 2);
+		gDPHudRectangle(gdl++, x, y + radius - 2, x, viewbottom - 10);
 	} else {
-		gDPHudRectangleCentered(gdl++, viewleft, y, x - radius + 2, y);
-		gDPHudRectangleCentered(gdl++, x + radius - 2, y, viewright, y);
-		gDPHudRectangleCentered(gdl++, x, viewtop, x, y - radius + 2);
-		gDPHudRectangleCentered(gdl++, x, y + radius - 2, x, viewbottom);
+		gDPHudRectangle(gdl++, viewleft, y, x - radius + 2, y);
+		gDPHudRectangle(gdl++, x + radius - 2, y, viewright, y);
+		gDPHudRectangle(gdl++, x, viewtop, x, y - radius + 2);
+		gDPHudRectangle(gdl++, x, y + radius - 2, x, viewbottom);
 	}
 
 	gdl = text0f153838(gdl);
 	gdl = textSetPrimColour(gdl, colour);
 
 	// Draw the box
-	gDPHudRectangleCentered(gdl++, x - radius, y - radius, x - radius, y + radius);
-	gDPHudRectangleCentered(gdl++, x + radius, y - radius, x + radius, y + radius);
-	gDPHudRectangleCentered(gdl++, x - radius, y - radius, x + radius, y - radius);
-	gDPHudRectangleCentered(gdl++, x - radius, y + radius, x + radius, y + radius);
+	gDPHudRectangle(gdl++, x - radius, y - radius, x - radius, y + radius);
+	gDPHudRectangle(gdl++, x + radius, y - radius, x + radius, y + radius);
+	gDPHudRectangle(gdl++, x - radius, y - radius, x + radius, y - radius);
+	gDPHudRectangle(gdl++, x - radius, y + radius, x + radius, y + radius);
 
 	// Go over the corners a second time
-	gDPHudRectangleCentered(gdl++, x - radius, y - radius, x - radius, y - cornergap);
-	gDPHudRectangleCentered(gdl++, x - radius, y + cornergap, x - radius, y + radius);
-	gDPHudRectangleCentered(gdl++, x + radius, y - radius, x + radius, y - cornergap);
-	gDPHudRectangleCentered(gdl++, x + radius, y + cornergap, x + radius, y + radius);
-	gDPHudRectangleCentered(gdl++, x - radius, y - radius, x - cornergap, y - radius);
-	gDPHudRectangleCentered(gdl++, x + cornergap, y - radius, x + radius, y - radius);
-	gDPHudRectangleCentered(gdl++, x - radius, y + radius, x - cornergap, y + radius);
-	gDPHudRectangleCentered(gdl++, x + cornergap, y + radius, x + radius, y + radius);
+	gDPHudRectangle(gdl++, x - radius, y - radius, x - radius, y - cornergap);
+	gDPHudRectangle(gdl++, x - radius, y + cornergap, x - radius, y + radius);
+	gDPHudRectangle(gdl++, x + radius, y - radius, x + radius, y - cornergap);
+	gDPHudRectangle(gdl++, x + radius, y + cornergap, x + radius, y + radius);
+	gDPHudRectangle(gdl++, x - radius, y - radius, x - cornergap, y - radius);
+	gDPHudRectangle(gdl++, x + cornergap, y - radius, x + radius, y - radius);
+	gDPHudRectangle(gdl++, x - radius, y + radius, x - cornergap, y + radius);
+	gDPHudRectangle(gdl++, x + cornergap, y + radius, x + radius, y + radius);
 
 #ifndef PLATFORM_N64
 	gSPClearExtraGeometryModeEXT(gdl++, G_ASPECT_CENTER_EXT);
+	gDPSetSubpixelOffsetEXT(gdl++, 0, 0);
 #endif
 
 	gdl = text0f153838(gdl);
@@ -1354,47 +1356,49 @@ Gfx *sightDrawZoom(Gfx *gdl, bool sighton)
 
 #ifndef PLATFORM_N64
 		gSPSetExtraGeometryModeEXT(gdl++, G_ASPECT_CENTER_EXT);
+		gDPSetSubpixelOffsetEXT(gdl++, -2, -2);
 #endif
 
 		// Top left
-		gDPHudRectangleCentered(gdl++, BOXLEFT + 1, BOXTOP, BOXLEFT + cornerwidth - 1, BOXTOP);
-		gDPHudRectangleCentered(gdl++, BOXLEFT, BOXTOP, BOXLEFT, BOXTOP + cornerheight - 1);
+		gDPHudRectangle(gdl++, BOXLEFT + 1, BOXTOP, BOXLEFT + cornerwidth - 1, BOXTOP);
+		gDPHudRectangle(gdl++, BOXLEFT, BOXTOP, BOXLEFT, BOXTOP + cornerheight - 1);
 
 		// Top right
-		gDPHudRectangleCentered(gdl++, BOXRIGHT - cornerwidth + 2, BOXTOP, BOXRIGHT - 1, BOXTOP);
-		gDPHudRectangleCentered(gdl++, BOXRIGHT, BOXTOP, BOXRIGHT, BOXTOP + cornerheight - 1);
+		gDPHudRectangle(gdl++, BOXRIGHT - cornerwidth + 2, BOXTOP, BOXRIGHT - 1, BOXTOP);
+		gDPHudRectangle(gdl++, BOXRIGHT, BOXTOP, BOXRIGHT, BOXTOP + cornerheight - 1);
 
 		// Bottom left
-		gDPHudRectangleCentered(gdl++, BOXLEFT + 1, BOXBOTTOM, BOXLEFT + cornerwidth - 1, BOXBOTTOM);
-		gDPHudRectangleCentered(gdl++, BOXLEFT, BOXBOTTOM - cornerheight + 1, BOXLEFT, BOXBOTTOM);
+		gDPHudRectangle(gdl++, BOXLEFT + 1, BOXBOTTOM, BOXLEFT + cornerwidth - 1, BOXBOTTOM);
+		gDPHudRectangle(gdl++, BOXLEFT, BOXBOTTOM - cornerheight + 1, BOXLEFT, BOXBOTTOM);
 
 		// Bottom right
-		gDPHudRectangleCentered(gdl++, BOXRIGHT - cornerwidth + 2, BOXBOTTOM, BOXRIGHT - 1, BOXBOTTOM);
-		gDPHudRectangleCentered(gdl++, BOXRIGHT, BOXBOTTOM - cornerheight + 1, BOXRIGHT, BOXBOTTOM);
+		gDPHudRectangle(gdl++, BOXRIGHT - cornerwidth + 2, BOXBOTTOM, BOXRIGHT - 1, BOXBOTTOM);
+		gDPHudRectangle(gdl++, BOXRIGHT, BOXBOTTOM - cornerheight + 1, BOXRIGHT, BOXBOTTOM);
 
 		// Draw over the corners again, but only half as wide/high
 		cornerwidth >>= 1;
 		cornerheight >>= 1;
 
 		// Top left
-		gDPHudRectangleCentered(gdl++, BOXLEFT, BOXTOP, BOXLEFT + cornerwidth, BOXTOP);
-		gDPHudRectangleCentered(gdl++, BOXLEFT, BOXTOP, BOXLEFT, BOXTOP + cornerheight);
+		gDPHudRectangle(gdl++, BOXLEFT, BOXTOP, BOXLEFT + cornerwidth, BOXTOP);
+		gDPHudRectangle(gdl++, BOXLEFT, BOXTOP, BOXLEFT, BOXTOP + cornerheight);
 
 		// Top right
-		gDPHudRectangleCentered(gdl++, BOXRIGHT - cornerwidth, BOXTOP, BOXRIGHT, BOXTOP);
-		gDPHudRectangleCentered(gdl++, BOXRIGHT, BOXTOP, BOXRIGHT, BOXTOP + cornerheight);
+		gDPHudRectangle(gdl++, BOXRIGHT - cornerwidth, BOXTOP, BOXRIGHT, BOXTOP);
+		gDPHudRectangle(gdl++, BOXRIGHT, BOXTOP, BOXRIGHT, BOXTOP + cornerheight);
 
 		// Bottom left
-		gDPHudRectangleCentered(gdl++, BOXLEFT, BOXBOTTOM, BOXLEFT + cornerwidth, BOXBOTTOM);
-		gDPHudRectangleCentered(gdl++, BOXLEFT, BOXBOTTOM - cornerheight, BOXLEFT, BOXBOTTOM);
+		gDPHudRectangle(gdl++, BOXLEFT, BOXBOTTOM, BOXLEFT + cornerwidth, BOXBOTTOM);
+		gDPHudRectangle(gdl++, BOXLEFT, BOXBOTTOM - cornerheight, BOXLEFT, BOXBOTTOM);
 
 		// Bottom right
-		gDPHudRectangleCentered(gdl++, BOXRIGHT - cornerwidth, BOXBOTTOM, BOXRIGHT, BOXBOTTOM);
-		gDPHudRectangleCentered(gdl++, BOXRIGHT, BOXBOTTOM - cornerheight, BOXRIGHT, BOXBOTTOM);
+		gDPHudRectangle(gdl++, BOXRIGHT - cornerwidth, BOXBOTTOM, BOXRIGHT, BOXBOTTOM);
+		gDPHudRectangle(gdl++, BOXRIGHT, BOXBOTTOM - cornerheight, BOXRIGHT, BOXBOTTOM);
 
 
 #ifndef PLATFORM_N64
 		gSPClearExtraGeometryModeEXT(gdl++, G_ASPECT_CENTER_EXT);
+		gDPSetSubpixelOffsetEXT(gdl++, 0, 0);
 #endif
 
 		gdl = text0f153838(gdl);
@@ -1433,6 +1437,7 @@ Gfx *sightDrawMaian(Gfx *gdl, bool sighton)
 #ifndef PLATFORM_N64
 	x = sightGetAdjustedX(x);
 	gSPSetExtraGeometryModeEXT(gdl++, G_ASPECT_CENTER_EXT);
+	gDPSetSubpixelOffsetEXT(gdl++, -2, -2);
 #endif
 
 	vertices = gfxAllocateVertices(8);
@@ -1498,15 +1503,16 @@ Gfx *sightDrawMaian(Gfx *gdl, bool sighton)
 	gdl = textSetPrimColour(gdl, SIGHT_COLOUR);
 
 	// Draw border over inner points
-	gDPHudRectangleCentered(gdl++, x - 4, y - 4, x - 4, y + 4); // left
-	gDPHudRectangleCentered(gdl++, x + 4, y - 4, x + 4, y + 4); // right
-	gDPHudRectangleCentered(gdl++, x - 4, y - 4, x + 4, y - 4); // top
-	gDPHudRectangleCentered(gdl++, x - 4, y + 4, x + 4, y + 4); // bottom
+	gDPHudRectangle(gdl++, x - 4, y - 4, x - 4, y + 4); // left
+	gDPHudRectangle(gdl++, x + 4, y - 4, x + 4, y + 4); // right
+	gDPHudRectangle(gdl++, x - 4, y - 4, x + 4, y - 4); // top
+	gDPHudRectangle(gdl++, x - 4, y + 4, x + 4, y + 4); // bottom
 
 	gdl = text0f153838(gdl);
 
 #ifndef PLATFORM_N64
 	gSPClearExtraGeometryModeEXT(gdl++, G_ASPECT_CENTER_EXT);
+	gDPSetSubpixelOffsetEXT(gdl++, 0, 0);
 #endif
 
 	return gdl;
@@ -1527,24 +1533,26 @@ Gfx *sightDrawTarget(Gfx *gdl)
 
 #ifndef PLATFORM_N64
 	gSPSetExtraGeometryModeEXT(gdl++, G_ASPECT_CENTER_EXT);
+	gDPSetSubpixelOffsetEXT(gdl++, -2, -2);
 	if (SIGHT_SCALE == 0) {
 		// Draw single rectangle to preserve intended opacity
-		gDPHudRectangleCentered(gdl++, x, y, x, y);
+		gDPHudRectangle(gdl++, x, y, x, y);
 	} else
 #endif
 	{
-		gDPHudRectangleCentered(gdl++, x + 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x + 3 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
-		gDPHudRectangleCentered(gdl++, x + 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x + 2 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
-		gDPHudRectangleCentered(gdl++, x - 3 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x - 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
-		gDPHudRectangleCentered(gdl++, x - 2 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x - 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
-		gDPHudRectangleCentered(gdl++, x + 0 * SIGHT_SCALE, y + 1 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y + 3 * SIGHT_SCALE);
-		gDPHudRectangleCentered(gdl++, x + 0 * SIGHT_SCALE, y + 1 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y + 2 * SIGHT_SCALE);
-		gDPHudRectangleCentered(gdl++, x + 0 * SIGHT_SCALE, y - 3 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y - 1 * SIGHT_SCALE);
-		gDPHudRectangleCentered(gdl++, x + 0 * SIGHT_SCALE, y - 2 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y - 1 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x + 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x + 3 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x + 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x + 2 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x - 3 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x - 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x - 2 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x - 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x + 0 * SIGHT_SCALE, y + 1 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y + 3 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x + 0 * SIGHT_SCALE, y + 1 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y + 2 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x + 0 * SIGHT_SCALE, y - 3 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y - 1 * SIGHT_SCALE);
+		gDPHudRectangle(gdl++, x + 0 * SIGHT_SCALE, y - 2 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y - 1 * SIGHT_SCALE);
 	}
 
 #ifndef PLATFORM_N64
 	gSPClearExtraGeometryModeEXT(gdl++, G_ASPECT_CENTER_EXT);
+	gDPSetSubpixelOffsetEXT(gdl++, 0, 0);
 #endif
 
 	gdl = text0f153838(gdl);

--- a/src/game/sight.c
+++ b/src/game/sight.c
@@ -1036,6 +1036,14 @@ Gfx *sightDrawSkedarTriangle(Gfx *gdl, s32 x, s32 y, s32 dir, u32 colour)
 	vertices[2].y = points[5] * 10;
 	vertices[2].z = -10;
 
+#ifndef PLATFORM_N64
+	// Center-align Skedar tris
+	for (int i = 0; i < 3; ++i) {
+		vertices[i].x -= 2;
+		vertices[i].y += 2;
+	}
+#endif
+
 	// @bug: This also needs to check for COLOUR_LIGHTRED because the caller can
 	// use two shades of red. The second colour is used when zeroing the sight
 	// in on a new target. Because of this bug, targeting an ally with the
@@ -1333,13 +1341,15 @@ Gfx *sightDrawZoom(Gfx *gdl, bool sighton)
 		marginbottom = viewhalfheight - availablebelow * frac;
 		margintop = viewhalfheight - availableabove * frac;
 
-		// Center-align the zoom range.
+#ifndef PLATFORM_N64
+		// Center-align the zoom range
 		if (frac != 1.0f) {
 			viewleft += 1;
 			viewright += 1;
 			viewbottom += 1;
 			viewtop += 1;
 		}
+#endif
 
 #define BOXLEFT   (viewleft + marginleft)
 #define BOXRIGHT  (viewright - marginright)
@@ -1481,6 +1491,14 @@ Gfx *sightDrawMaian(Gfx *gdl, bool sighton)
 	vertices[7].x = inner[1] * 10;
 	vertices[7].y = inner[2] * 10;
 	vertices[7].z = -10;
+
+#ifndef PLATFORM_N64
+	// Center-align Maian tris
+	for (int i = 0; i < 8; ++i) {
+		vertices[i].x -= 2;
+		vertices[i].y += 2;
+	}
+#endif
 
 	colours[0].word = PD_BE32(0x00ff000f);
 	colours[1].word = PD_BE32(hasprop ? colour : 0x00ff0044);

--- a/src/game/sight.c
+++ b/src/game/sight.c
@@ -1602,6 +1602,16 @@ Gfx *sightDraw(Gfx *gdl, bool sighton, s32 sight)
 		return gdl;
 	}
 
+#ifndef PLATFORM_N64
+	// Rounding the crosshair positions allow them to more accurately follow the
+	// gun's vector. Without this, the mantissa isn't factored in at all (cast
+	// to integer), which leads to some awkward behavior, such as the crosshair
+	// taking a long time to return to the center of the screen when coming from
+	// an up and/or left direction.
+	g_Vars.currentplayer->crosspos[0] = roundf(g_Vars.currentplayer->crosspos[0]);
+	g_Vars.currentplayer->crosspos[1] = roundf(g_Vars.currentplayer->crosspos[1]);
+#endif
+
 #if PAL
 	g_ScaleX = 1;
 #else

--- a/src/game/sight.c
+++ b/src/game/sight.c
@@ -519,35 +519,35 @@ Gfx *sightDrawAimer(Gfx *gdl, s32 x, s32 y, s32 radius, s32 cornergap, u32 colou
 
 	// Draw the lines that span most of the viewport
 	if (PLAYERCOUNT() == 1) {
-		gDPHudRectangle(gdl++, viewleft + 48, y, x - radius + 2, y);
-		gDPHudRectangle(gdl++, x + radius - 2, y, viewright - 49, y);
-		gDPHudRectangle(gdl++, x, viewtop + 10, x, y - radius + 2);
-		gDPHudRectangle(gdl++, x, y + radius - 2, x, viewbottom - 10);
+		gDPHudRectangleCentered(gdl++, viewleft + 48, y, x - radius + 2, y);
+		gDPHudRectangleCentered(gdl++, x + radius - 2, y, viewright - 49, y);
+		gDPHudRectangleCentered(gdl++, x, viewtop + 10, x, y - radius + 2);
+		gDPHudRectangleCentered(gdl++, x, y + radius - 2, x, viewbottom - 10);
 	} else {
-		gDPHudRectangle(gdl++, viewleft, y, x - radius + 2, y);
-		gDPHudRectangle(gdl++, x + radius - 2, y, viewright, y);
-		gDPHudRectangle(gdl++, x, viewtop, x, y - radius + 2);
-		gDPHudRectangle(gdl++, x, y + radius - 2, x, viewbottom);
+		gDPHudRectangleCentered(gdl++, viewleft, y, x - radius + 2, y);
+		gDPHudRectangleCentered(gdl++, x + radius - 2, y, viewright, y);
+		gDPHudRectangleCentered(gdl++, x, viewtop, x, y - radius + 2);
+		gDPHudRectangleCentered(gdl++, x, y + radius - 2, x, viewbottom);
 	}
 
 	gdl = text0f153838(gdl);
 	gdl = textSetPrimColour(gdl, colour);
 
 	// Draw the box
-	gDPHudRectangle(gdl++, x - radius, y - radius, x - radius, y + radius);
-	gDPHudRectangle(gdl++, x + radius, y - radius, x + radius, y + radius);
-	gDPHudRectangle(gdl++, x - radius, y - radius, x + radius, y - radius);
-	gDPHudRectangle(gdl++, x - radius, y + radius, x + radius, y + radius);
+	gDPHudRectangleCentered(gdl++, x - radius, y - radius, x - radius, y + radius);
+	gDPHudRectangleCentered(gdl++, x + radius, y - radius, x + radius, y + radius);
+	gDPHudRectangleCentered(gdl++, x - radius, y - radius, x + radius, y - radius);
+	gDPHudRectangleCentered(gdl++, x - radius, y + radius, x + radius, y + radius);
 
 	// Go over the corners a second time
-	gDPHudRectangle(gdl++, x - radius, y - radius, x - radius, y - cornergap);
-	gDPHudRectangle(gdl++, x - radius, y + cornergap, x - radius, y + radius);
-	gDPHudRectangle(gdl++, x + radius, y - radius, x + radius, y - cornergap);
-	gDPHudRectangle(gdl++, x + radius, y + cornergap, x + radius, y + radius);
-	gDPHudRectangle(gdl++, x - radius, y - radius, x - cornergap, y - radius);
-	gDPHudRectangle(gdl++, x + cornergap, y - radius, x + radius, y - radius);
-	gDPHudRectangle(gdl++, x - radius, y + radius, x - cornergap, y + radius);
-	gDPHudRectangle(gdl++, x + cornergap, y + radius, x + radius, y + radius);
+	gDPHudRectangleCentered(gdl++, x - radius, y - radius, x - radius, y - cornergap);
+	gDPHudRectangleCentered(gdl++, x - radius, y + cornergap, x - radius, y + radius);
+	gDPHudRectangleCentered(gdl++, x + radius, y - radius, x + radius, y - cornergap);
+	gDPHudRectangleCentered(gdl++, x + radius, y + cornergap, x + radius, y + radius);
+	gDPHudRectangleCentered(gdl++, x - radius, y - radius, x - cornergap, y - radius);
+	gDPHudRectangleCentered(gdl++, x + cornergap, y - radius, x + radius, y - radius);
+	gDPHudRectangleCentered(gdl++, x - radius, y + radius, x - cornergap, y + radius);
+	gDPHudRectangleCentered(gdl++, x + cornergap, y + radius, x + radius, y + radius);
 
 #ifndef PLATFORM_N64
 	gSPClearExtraGeometryModeEXT(gdl++, G_ASPECT_CENTER_EXT);
@@ -908,7 +908,7 @@ Gfx *sightDrawClassic(Gfx *gdl, bool sighton)
 	f32 spc4[2];
 	f32 spbc[2];
 	s32 x = g_Vars.currentplayer->crosspos[0];
-	s32 y = g_Vars.currentplayer->crosspos[1];
+	s32 y = g_Vars.currentplayer->crosspos[1] + 1; // Plus one, to align with the laser sight.
 	s32 x1;
 	s32 x2;
 	s32 y1;
@@ -1331,6 +1331,14 @@ Gfx *sightDrawZoom(Gfx *gdl, bool sighton)
 		marginbottom = viewhalfheight - availablebelow * frac;
 		margintop = viewhalfheight - availableabove * frac;
 
+		// Center-align the zoom range.
+		if (frac != 1.0f) {
+			viewleft += 1;
+			viewright += 1;
+			viewbottom += 1;
+			viewtop += 1;
+		}
+
 #define BOXLEFT   (viewleft + marginleft)
 #define BOXRIGHT  (viewright - marginright)
 #define BOXBOTTOM (viewbottom - marginbottom)
@@ -1349,40 +1357,40 @@ Gfx *sightDrawZoom(Gfx *gdl, bool sighton)
 #endif
 
 		// Top left
-		gDPHudRectangle(gdl++, BOXLEFT + 1, BOXTOP, BOXLEFT + cornerwidth - 1, BOXTOP);
-		gDPHudRectangle(gdl++, BOXLEFT, BOXTOP, BOXLEFT, BOXTOP + cornerheight - 1);
+		gDPHudRectangleCentered(gdl++, BOXLEFT + 1, BOXTOP, BOXLEFT + cornerwidth - 1, BOXTOP);
+		gDPHudRectangleCentered(gdl++, BOXLEFT, BOXTOP, BOXLEFT, BOXTOP + cornerheight - 1);
 
 		// Top right
-		gDPHudRectangle(gdl++, BOXRIGHT - cornerwidth + 2, BOXTOP, BOXRIGHT - 1, BOXTOP);
-		gDPHudRectangle(gdl++, BOXRIGHT, BOXTOP, BOXRIGHT, BOXTOP + cornerheight - 1);
+		gDPHudRectangleCentered(gdl++, BOXRIGHT - cornerwidth + 2, BOXTOP, BOXRIGHT - 1, BOXTOP);
+		gDPHudRectangleCentered(gdl++, BOXRIGHT, BOXTOP, BOXRIGHT, BOXTOP + cornerheight - 1);
 
 		// Bottom left
-		gDPHudRectangle(gdl++, BOXLEFT + 1, BOXBOTTOM, BOXLEFT + cornerwidth - 1, BOXBOTTOM);
-		gDPHudRectangle(gdl++, BOXLEFT, BOXBOTTOM - cornerheight + 1, BOXLEFT, BOXBOTTOM);
+		gDPHudRectangleCentered(gdl++, BOXLEFT + 1, BOXBOTTOM, BOXLEFT + cornerwidth - 1, BOXBOTTOM);
+		gDPHudRectangleCentered(gdl++, BOXLEFT, BOXBOTTOM - cornerheight + 1, BOXLEFT, BOXBOTTOM);
 
 		// Bottom right
-		gDPHudRectangle(gdl++, BOXRIGHT - cornerwidth + 2, BOXBOTTOM, BOXRIGHT - 1, BOXBOTTOM);
-		gDPHudRectangle(gdl++, BOXRIGHT, BOXBOTTOM - cornerheight + 1, BOXRIGHT, BOXBOTTOM);
+		gDPHudRectangleCentered(gdl++, BOXRIGHT - cornerwidth + 2, BOXBOTTOM, BOXRIGHT - 1, BOXBOTTOM);
+		gDPHudRectangleCentered(gdl++, BOXRIGHT, BOXBOTTOM - cornerheight + 1, BOXRIGHT, BOXBOTTOM);
 
 		// Draw over the corners again, but only half as wide/high
 		cornerwidth >>= 1;
 		cornerheight >>= 1;
 
 		// Top left
-		gDPHudRectangle(gdl++, BOXLEFT, BOXTOP, BOXLEFT + cornerwidth, BOXTOP);
-		gDPHudRectangle(gdl++, BOXLEFT, BOXTOP, BOXLEFT, BOXTOP + cornerheight);
+		gDPHudRectangleCentered(gdl++, BOXLEFT, BOXTOP, BOXLEFT + cornerwidth, BOXTOP);
+		gDPHudRectangleCentered(gdl++, BOXLEFT, BOXTOP, BOXLEFT, BOXTOP + cornerheight);
 
 		// Top right
-		gDPHudRectangle(gdl++, BOXRIGHT - cornerwidth, BOXTOP, BOXRIGHT, BOXTOP);
-		gDPHudRectangle(gdl++, BOXRIGHT, BOXTOP, BOXRIGHT, BOXTOP + cornerheight);
+		gDPHudRectangleCentered(gdl++, BOXRIGHT - cornerwidth, BOXTOP, BOXRIGHT, BOXTOP);
+		gDPHudRectangleCentered(gdl++, BOXRIGHT, BOXTOP, BOXRIGHT, BOXTOP + cornerheight);
 
 		// Bottom left
-		gDPHudRectangle(gdl++, BOXLEFT, BOXBOTTOM, BOXLEFT + cornerwidth, BOXBOTTOM);
-		gDPHudRectangle(gdl++, BOXLEFT, BOXBOTTOM - cornerheight, BOXLEFT, BOXBOTTOM);
+		gDPHudRectangleCentered(gdl++, BOXLEFT, BOXBOTTOM, BOXLEFT + cornerwidth, BOXBOTTOM);
+		gDPHudRectangleCentered(gdl++, BOXLEFT, BOXBOTTOM - cornerheight, BOXLEFT, BOXBOTTOM);
 
 		// Bottom right
-		gDPHudRectangle(gdl++, BOXRIGHT - cornerwidth, BOXBOTTOM, BOXRIGHT, BOXBOTTOM);
-		gDPHudRectangle(gdl++, BOXRIGHT, BOXBOTTOM - cornerheight, BOXRIGHT, BOXBOTTOM);
+		gDPHudRectangleCentered(gdl++, BOXRIGHT - cornerwidth, BOXBOTTOM, BOXRIGHT, BOXBOTTOM);
+		gDPHudRectangleCentered(gdl++, BOXRIGHT, BOXBOTTOM - cornerheight, BOXRIGHT, BOXBOTTOM);
 
 
 #ifndef PLATFORM_N64
@@ -1490,10 +1498,10 @@ Gfx *sightDrawMaian(Gfx *gdl, bool sighton)
 	gdl = textSetPrimColour(gdl, SIGHT_COLOUR);
 
 	// Draw border over inner points
-	gDPHudRectangle(gdl++, x - 4, y - 4, x - 4, y + 4); // left
-	gDPHudRectangle(gdl++, x + 4, y - 4, x + 4, y + 4); // right
-	gDPHudRectangle(gdl++, x - 4, y - 4, x + 4, y - 4); // top
-	gDPHudRectangle(gdl++, x - 4, y + 4, x + 4, y + 4); // bottom
+	gDPHudRectangleCentered(gdl++, x - 4, y - 4, x - 4, y + 4); // left
+	gDPHudRectangleCentered(gdl++, x + 4, y - 4, x + 4, y + 4); // right
+	gDPHudRectangleCentered(gdl++, x - 4, y - 4, x + 4, y - 4); // top
+	gDPHudRectangleCentered(gdl++, x - 4, y + 4, x + 4, y + 4); // bottom
 
 	gdl = text0f153838(gdl);
 
@@ -1521,18 +1529,18 @@ Gfx *sightDrawTarget(Gfx *gdl)
 	gSPSetExtraGeometryModeEXT(gdl++, G_ASPECT_CENTER_EXT);
 	if (SIGHT_SCALE == 0) {
 		// Draw single rectangle to preserve intended opacity
-		gDPHudRectangle(gdl++, x, y, x, y);
+		gDPHudRectangleCentered(gdl++, x, y, x, y);
 	} else
 #endif
 	{
-		gDPHudRectangle(gdl++, x + 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x + 3 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
-		gDPHudRectangle(gdl++, x + 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x + 2 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
-		gDPHudRectangle(gdl++, x - 3 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x - 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
-		gDPHudRectangle(gdl++, x - 2 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x - 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
-		gDPHudRectangle(gdl++, x + 0 * SIGHT_SCALE, y + 1 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y + 3 * SIGHT_SCALE);
-		gDPHudRectangle(gdl++, x + 0 * SIGHT_SCALE, y + 1 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y + 2 * SIGHT_SCALE);
-		gDPHudRectangle(gdl++, x + 0 * SIGHT_SCALE, y - 3 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y - 1 * SIGHT_SCALE);
-		gDPHudRectangle(gdl++, x + 0 * SIGHT_SCALE, y - 2 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y - 1 * SIGHT_SCALE);
+		gDPHudRectangleCentered(gdl++, x + 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x + 3 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
+		gDPHudRectangleCentered(gdl++, x + 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x + 2 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
+		gDPHudRectangleCentered(gdl++, x - 3 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x - 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
+		gDPHudRectangleCentered(gdl++, x - 2 * SIGHT_SCALE, y + 0 * SIGHT_SCALE, x - 1 * SIGHT_SCALE, y + 0 * SIGHT_SCALE);
+		gDPHudRectangleCentered(gdl++, x + 0 * SIGHT_SCALE, y + 1 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y + 3 * SIGHT_SCALE);
+		gDPHudRectangleCentered(gdl++, x + 0 * SIGHT_SCALE, y + 1 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y + 2 * SIGHT_SCALE);
+		gDPHudRectangleCentered(gdl++, x + 0 * SIGHT_SCALE, y - 3 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y - 1 * SIGHT_SCALE);
+		gDPHudRectangleCentered(gdl++, x + 0 * SIGHT_SCALE, y - 2 * SIGHT_SCALE, x + 0 * SIGHT_SCALE, y - 1 * SIGHT_SCALE);
 	}
 
 #ifndef PLATFORM_N64

--- a/src/include/gbiex.h
+++ b/src/include/gbiex.h
@@ -184,18 +184,19 @@
 
 /* Extended commands */
 
-#define G_SETFB_EXT             0x21
-#define G_SETTIMG_FB_EXT        0x23
-#define G_INVALTEXCACHE_EXT     0x34
-#define G_TEXRECT_WIDE_EXT      0x37
-#define G_FILLRECT_WIDE_EXT     0x38
-#define G_SETGRAYSCALE_EXT      0x39
-#define G_EXTRAGEOMETRYMODE_EXT 0x3a
-#define G_SETINTENSITY_EXT      0x40
-#define G_COPYFB_EXT            0x41
-#define G_IMAGERECT_EXT         0x42
-#define G_RDPFLUSH_EXT          0x43
-#define G_CLEAR_DEPTH_EXT       0x44
+#define G_SETFB_EXT                  0x21
+#define G_SETTIMG_FB_EXT             0x23
+#define G_INVALTEXCACHE_EXT          0x34
+#define G_TEXRECT_WIDE_EXT           0x37
+#define G_FILLRECT_WIDE_EXT          0x38
+#define G_SETGRAYSCALE_EXT           0x39
+#define G_EXTRAGEOMETRYMODE_EXT      0x3a
+#define G_SETINTENSITY_EXT           0x40
+#define G_COPYFB_EXT                 0x41
+#define G_IMAGERECT_EXT              0x42
+#define G_RDPFLUSH_EXT               0x43
+#define G_CLEAR_DEPTH_EXT            0x44
+#define G_FILLRECT_CENTERED_WIDE_EXT 0x45
 
 /* G_EXTRAGEOMETRYMODE flags */
 
@@ -260,6 +261,16 @@
     _g1->words.w1 = _SHIFTL((uly), 2, 22);                                       \
 }
 
+#define gDPFillRectangleCenteredWideEXT(pkt, ulx, uly, lrx, lry)                          \
+{                                                                                         \
+    Gfx *_g0 = (Gfx*)(pkt), *_g1 = (Gfx*)(pkt);                                           \
+                                                                                          \
+    _g0->words.w0 = _SHIFTL(G_FILLRECT_CENTERED_WIDE_EXT, 24, 8) | _SHIFTL((lrx), 2, 22); \
+    _g0->words.w1 = _SHIFTL((lry), 2, 22);                                                \
+    _g1->words.w0 = _SHIFTL((ulx), 2, 22);                                                \
+    _g1->words.w1 = _SHIFTL((uly), 2, 22);                                                \
+}
+
 #define gSPTextureRectangleWideEXT(pkt, xl, yl, xh, yh, tile, s, t, dsdx, dtdy, flip)         \
 {                                                                                             \
     Gfx *_g0 = (Gfx*)(pkt), *_g1 = (Gfx*)(pkt), *_g2 = (Gfx*)(pkt);                           \
@@ -296,6 +307,7 @@
 #define gSPClearExtraGeometryModeEXT(pkt, word) gSPExtraGeometryModeEXT((pkt), word, 0)
 
 #define gDPFillRectangleEXT gDPFillRectangleWideEXT
+#define gDPFillRectangleCenteredEXT gDPFillRectangleCenteredWideEXT
 #define gSPTextureRectangleEXT(p, xl, yl, xh, yh, tile, s, t, ds, dt) gSPTextureRectangleWideEXT(p, xl, yl, xh, yh, tile, s, t, ds, dt, G_OFF)
 #define gSPTextureRectangleFlipEXT(p, xl, yl, xh, yh, tile, s, t, ds, dt) gSPTextureRectangleWideEXT(p, xl, yl, xh, yh, tile, s, t, ds, dt, G_ON)
 
@@ -308,10 +320,12 @@
 
 #undef gDPHudRectangle
 #define gDPHudRectangle(pkt, x1, y1, x2, y2) gDPFillRectangleEXT(pkt, (x1) * g_ScaleX, y1, ((x2 + 1)) * g_ScaleX, (y2) + 1)
+#define gDPHudRectangleCentered(pkt, x1, y1, x2, y2) gDPFillRectangleCenteredEXT(pkt, (x1) * g_ScaleX, y1, ((x2 + 1)) * g_ScaleX, (y2) + 1)
 
 #else // PLATFORM_N64
 
 #define gDPFillRectangleEXT gDPFillRectangle
+#define gDPFillRectangleCenteredEXT gDPFillRectangle
 #define gSPTextureRectangleEXT gSPTextureRectangle
 
 #endif // PLATFORM_N64

--- a/src/include/gbiex.h
+++ b/src/include/gbiex.h
@@ -196,7 +196,7 @@
 #define G_IMAGERECT_EXT              0x42
 #define G_RDPFLUSH_EXT               0x43
 #define G_CLEAR_DEPTH_EXT            0x44
-#define G_FILLRECT_CENTERED_WIDE_EXT 0x45
+#define G_SETSUBPIXELOFFSET_EXT      0x45
 
 /* G_EXTRAGEOMETRYMODE flags */
 
@@ -261,16 +261,6 @@
     _g1->words.w1 = _SHIFTL((uly), 2, 22);                                       \
 }
 
-#define gDPFillRectangleCenteredWideEXT(pkt, ulx, uly, lrx, lry)                          \
-{                                                                                         \
-    Gfx *_g0 = (Gfx*)(pkt), *_g1 = (Gfx*)(pkt);                                           \
-                                                                                          \
-    _g0->words.w0 = _SHIFTL(G_FILLRECT_CENTERED_WIDE_EXT, 24, 8) | _SHIFTL((lrx), 2, 22); \
-    _g0->words.w1 = _SHIFTL((lry), 2, 22);                                                \
-    _g1->words.w0 = _SHIFTL((ulx), 2, 22);                                                \
-    _g1->words.w1 = _SHIFTL((uly), 2, 22);                                                \
-}
-
 #define gSPTextureRectangleWideEXT(pkt, xl, yl, xh, yh, tile, s, t, dsdx, dtdy, flip)         \
 {                                                                                             \
     Gfx *_g0 = (Gfx*)(pkt), *_g1 = (Gfx*)(pkt), *_g2 = (Gfx*)(pkt);                           \
@@ -303,11 +293,18 @@
     _g->words.w1 = (u32)(s);                                                            \
 }
 
+#define gDPSetSubpixelOffsetEXT(pkt, x, y)                                             \
+{                                                                                      \
+    Gfx *_g = (Gfx*)(pkt);                                                             \
+                                                                                       \
+    _g->words.w0 = _SHIFTL(G_SETSUBPIXELOFFSET_EXT, 24, 8) | _SHIFTL((s16)(x), 0, 16); \
+    _g->words.w1 = _SHIFTL((s16)(y), 0, 16);                                           \
+}
+
 #define gSPSetExtraGeometryModeEXT(pkt, word) gSPExtraGeometryModeEXT((pkt), 0, word)
 #define gSPClearExtraGeometryModeEXT(pkt, word) gSPExtraGeometryModeEXT((pkt), word, 0)
 
 #define gDPFillRectangleEXT gDPFillRectangleWideEXT
-#define gDPFillRectangleCenteredEXT gDPFillRectangleCenteredWideEXT
 #define gSPTextureRectangleEXT(p, xl, yl, xh, yh, tile, s, t, ds, dt) gSPTextureRectangleWideEXT(p, xl, yl, xh, yh, tile, s, t, ds, dt, G_OFF)
 #define gSPTextureRectangleFlipEXT(p, xl, yl, xh, yh, tile, s, t, ds, dt) gSPTextureRectangleWideEXT(p, xl, yl, xh, yh, tile, s, t, ds, dt, G_ON)
 
@@ -320,12 +317,10 @@
 
 #undef gDPHudRectangle
 #define gDPHudRectangle(pkt, x1, y1, x2, y2) gDPFillRectangleEXT(pkt, (x1) * g_ScaleX, y1, ((x2 + 1)) * g_ScaleX, (y2) + 1)
-#define gDPHudRectangleCentered(pkt, x1, y1, x2, y2) gDPFillRectangleCenteredEXT(pkt, (x1) * g_ScaleX, y1, ((x2 + 1)) * g_ScaleX, (y2) + 1)
 
 #else // PLATFORM_N64
 
 #define gDPFillRectangleEXT gDPFillRectangle
-#define gDPFillRectangleCenteredEXT gDPFillRectangle
 #define gSPTextureRectangleEXT gSPTextureRectangle
 
 #endif // PLATFORM_N64


### PR DESCRIPTION
This fixes #273, ~~albeit with some room for improvement.~~

My original intention was to shift the post-scaled crosshair over by a resolution-dependent amount of pixels, in order to align it with the laser sight. However, I eventually noticed that the granularity of the rects was increased by 4x, once it was placed on the graphics display list (I'm not at all familiar with N64 technical details), which gave me enough precision to center it perfectly with the laser. Essentially, I solved this issue by creating a unique RDP opcode to handle the placement of the crosshairs. The original `gDPHudRectangle` macro was preserved, since the rect drawn around enemies, when aiming at them with a CMP150, was more accurately placed with it. In addition, the zoom range was also adjusted to align with the crosshair.

~~Some caveats to note:~~ **All caveats have been addressed.**
~~* With Crosshair Sway enabled, if the sway direction is up and/or left, it takes roughly one second for the crosshair to return to its origin. The original crosshair placement looks more correct, during this timeframe.~~
~~* The Skedar and Maian sights aren't perfectly aligned with the crosshair. The Maian one is much improved, but the Skedar one is actually slightly worse. I'm not even sure how, since I didn't modify how the Skedar sight was rendered at all.~~

<details><summary>Click here for some before and after screenshots, with a superimposed 32x32 grid to aid with visualizing the alignment. (OUTDATED)</summary>
<p>

Original crosshair (1x size):
![orig-crosshair](https://github.com/user-attachments/assets/b06ebd60-57a6-4ff1-8959-2ee8d18c71b7)
New crosshair (1x size):
![new-crosshair](https://github.com/user-attachments/assets/b831c564-655e-4fdb-b413-77a8f5a3e568)

Original classic sight:
![orig-classic](https://github.com/user-attachments/assets/0bd7755b-c964-48ff-8748-0c95aa91f202)
New classic sight:
![new-classic](https://github.com/user-attachments/assets/b94c79f3-8c6a-4d50-b788-cd63612d5e6c)

Original sniper zoom range (30x zoom)
![orig-sniper-zoom](https://github.com/user-attachments/assets/76271d79-af03-4b80-ad75-b783dbb743b6)
new sniper zoom range (30x zoom)
![new-sniper-zoom](https://github.com/user-attachments/assets/d7cd8e23-d2c0-44f6-abe8-0df03873cc94)

Original Maian sight:
![orig-maian-zoom](https://github.com/user-attachments/assets/de7d82c1-683f-44e5-8848-a805dd65d71f)
New Maian sight:
![new-maian-zoom](https://github.com/user-attachments/assets/1cf42673-0e49-43a3-95b5-f382c2395a97)

Original Skedar sight:
![orig-skedar-zoom](https://github.com/user-attachments/assets/70c04469-7a39-4d05-9d96-1a6eea884b32)
New Skedar sight:
![new-skedar-zoom](https://github.com/user-attachments/assets/23971bae-6122-4df8-b8f9-3b85b0475205)

Original DrugSpy crosshair:
![orig-drugspy](https://github.com/user-attachments/assets/c8c455c2-4e4a-4b6d-afe1-680677a4e2ed)
New DrugSpy crosshair:
![new-drugspy](https://github.com/user-attachments/assets/32f92a74-e896-4a2d-a0a4-53ae6db48895)

</p>
</details>
