### PR TITLE
Fixes MP NVG flashing bug

### DIFF
--- a/src/game/propobj.c
+++ b/src/game/propobj.c
@@ -1615,7 +1615,19 @@ void propCalculateShadeColour(struct prop *prop, u8 *nextcol, u16 floorcol)
 #endif
 	{
 		s32 shade = func0f068fc8(prop, 0);
-
+		if (USINGDEVICE(DEVICE_NIGHTVISION)) {
+			switch (prop->type) {
+				case PROPTYPE_PLAYER:
+				if (g_Vars.currentplayer->prop == prop) {
+					break;
+				}
+				default:
+				if (prop->rooms[0] >= 0) {
+					shade = g_Rooms[prop->rooms[0]].br_settled_regional;
+				}
+				break;
+			}
+		}
 		roomr = shade;
 		roomg = shade;
 		roomb = shade;


### PR DESCRIPTION
Perfect Dark has some issues w/ NVGs in multiplayer modes when at least one player is using NVGs and at least one is not. With Perfect Darkness + CS, the ammo boxes and other props will flash for players. In coop, the other player will see other characters and props flash.

I've confirmed this is an N64 issue w/ an ares capture:

https://github.com/user-attachments/assets/52f6cd9d-55f4-4ae5-a7be-6505dbed46f9


