### PR TITLE
Fix mouselook causing softlock in The Duel

### DIFF
--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -773,7 +773,13 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 
 #ifndef PLATFORM_N64
 	if (allowmlook) {
-		inputMouseGetScaledDelta(&movedata.freelookdx, &movedata.freelookdy);
+		if (!g_PlayerResetIssued) {
+			inputMouseGetScaledDelta(&movedata.freelookdx, &movedata.freelookdy);
+		} else {
+			movedata.freelookdx = 0.0f;
+			movedata.freelookdy = 0.0f;
+			g_PlayerResetIssued = false;
+		}
 		allowmcross = (PLAYER_EXTCFG().mouseaimmode == MOUSEAIM_CLASSIC) &&
 			(movedata.freelookdx || movedata.freelookdy || g_Vars.currentplayer->swivelpos[0] || g_Vars.currentplayer->swivelpos[1]);
 		if (movedata.invertpitch) {

--- a/src/game/playerreset.c
+++ b/src/game/playerreset.c
@@ -24,6 +24,10 @@
 #include "data.h"
 #include "types.h"
 
+#ifndef PLATFORM_N64
+bool g_PlayerResetIssued = false;
+#endif
+
 void playerInitEyespy(void)
 {
 	struct prop *prop;
@@ -109,6 +113,9 @@ struct cmd32 {
 
 void playerReset(void)
 {
+#ifndef PLATFORM_N64
+	g_PlayerResetIssued = true;
+#endif
 	struct coord pos = {0, 0, 0};
 	RoomNum rooms[8];
 	f32 turnanglerad = 0;

--- a/src/include/data.h
+++ b/src/include/data.h
@@ -554,6 +554,7 @@ extern s32 g_TickExtraSleep;
 extern s32 g_MusicDisableMpDeath;
 extern s32 g_BgunGeMuzzleFlashes;
 extern s32 g_FileAutoSelect;
+extern bool g_PlayerResetIssued;
 
 #define PLAYER_EXTCFG() g_PlayerExtCfg[g_Vars.currentplayerstats->mpindex & 3]
 #define PLAYER_DEFAULT_FOV (PLAYER_EXTCFG().fovy)


### PR DESCRIPTION
Moving the mouse could cause Joanna's starting angle to be incorrect, leading to a soft lock in The Duel. I tried to solve this issue using my `inputResetRelativeMouseState` function from my prior PR #530, but to no avail. So, I spun this off into its own PR. My current solution is to force `movedata.freelookdx` and `movedata.freelookdy` to be zero, any time `playerReset` is called. It gets the job done, but it's kind of hacky. Any suggestions would be appreciated.