### PR TITLE
Discard player momentum during autowalk sequences

### DIFF
--- a/src/game/player.c
+++ b/src/game/player.c
@@ -3107,6 +3107,9 @@ void playerAutoWalk(s16 aimpad, u8 walkspeed, u8 turnspeed, u8 lookup, u8 dist)
 {
 	playerSetTickMode(TICKMODE_AUTOWALK);
 
+	// Prevents momentum from being preserved. Fixes potential softlock during The Duel.
+	g_Vars.currentplayer->resetheadpos = true;
+
 	g_Vars.currentplayer->autocontrol_aimpad = aimpad;
 	g_Vars.currentplayer->autocontrol_walkspeed = walkspeed;
 	g_Vars.currentplayer->autocontrol_turnspeed = turnspeed;


### PR DESCRIPTION
Fixes #533. I also checked and made sure that the Extraction autowalk sequence wasn't botched by this solution, which I believe is the only other time autowalk is used in the game.