### PR TITLE
Clamp gunzoomfovs to accommodate modified player FOV

### DIFF
--- a/src/game/game_0b0fd0.c
+++ b/src/game/game_0b0fd0.c
@@ -208,6 +208,14 @@ f32 currentPlayerGetGunZoomFov(void)
 	}
 
 	if (index >= 0) {
+#ifndef PLATFORM_N64
+		// Make sure gunzoomfovs are clamped when the player changes their FOV.
+		if (g_Vars.currentplayer->gunzoomfovs[index] > ADJUST_ZOOM_FOV(60)) {
+			g_Vars.currentplayer->gunzoomfovs[index] = ADJUST_ZOOM_FOV(60);
+		} else if (g_Vars.currentplayer->gunzoomfovs[index] < ADJUST_ZOOM_FOV(2)) {
+			g_Vars.currentplayer->gunzoomfovs[index] = ADJUST_ZOOM_FOV(2);
+		}
+#endif
 		return g_Vars.currentplayer->gunzoomfovs[index];
 	}
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/6d56c65f-6b9d-46fc-adb1-48a13f1070af

When a gun with variable zoom FOV is set to its minimum or maximum, it can easily exceed its limits if the player changes their vertical FOV from the menu. The additional clamping logic keeps it within its boundaries after an FOV change (only has an effect if FovAffectsZoom is 1).