### PR TITLE
Ergonomic upgrades for menu sliders while using the mouse

### DIFF
--- a/src/game/menu.c
+++ b/src/game/menu.c
@@ -142,6 +142,9 @@ s32 g_MpPlayerNum = 0;
 s32 g_MenuMouseControl = true;
 s32 g_MenuUsingMouse = false;
 s32 g_MenuKeyboardPlayer = -1;
+s32 g_AllowMouseHeld = true;
+s32 g_MouseDimmedMode = false;
+s32 g_MouseEndDeferredSlider = false;
 #endif
 
 void menuPlaySound(s32 menusound)
@@ -1512,6 +1515,12 @@ void menuOpenDialog(struct menudialogdef *dialogdef, struct menudialog *dialog, 
 
 void menuPushDialog(struct menudialogdef *dialogdef)
 {
+#ifndef PLATFORM_N64
+	// Prevent the mouse from immediately changing a slider's value, as was
+	// happening while entering the Audio menu.
+	g_AllowMouseHeld = false;
+#endif
+
 	if (dialogdef) {
 		menuUnsetModel(&g_Menus[g_MpPlayerNum].menumodel);
 
@@ -4700,6 +4709,7 @@ void menuProcessInput(void)
 	inputs.back2 = 0;
 
 #ifndef PLATFORM_N64
+	inputs.mouseheld = false;
 	inputs.mousemoved = false;
 	inputs.mousescroll = 0;
 	inputs.mousex = 0;
@@ -4709,6 +4719,14 @@ void menuProcessInput(void)
 		// ESC always acts as back
 		inputs.back = inputKeyJustPressed(VK_ESCAPE);
 		if (inputMouseIsEnabled() && !inputMouseIsLocked() && g_MenuMouseControl) {
+			inputs.mouseheld = inputKeyPressed(VK_MOUSE_LEFT);
+			if (!inputs.mouseheld) {
+				g_AllowMouseHeld = true;
+				if (g_MouseDimmedMode) {
+					g_MouseDimmedMode = false;
+					g_MouseEndDeferredSlider = true;
+				}
+			}
 			inputs.mousescroll = inputKeyPressed(VK_MOUSE_WHEEL_DN) - inputKeyPressed(VK_MOUSE_WHEEL_UP);
 			inputs.mousemoved = inputMouseGetPosition(&inputs.mousex, &inputs.mousey) || inputs.mousescroll;
 			// aspect correct the X

--- a/src/game/menu.c
+++ b/src/game/menu.c
@@ -4709,8 +4709,8 @@ void menuProcessInput(void)
 		// ESC always acts as back
 		inputs.back = inputKeyJustPressed(VK_ESCAPE);
 		if (inputMouseIsEnabled() && !inputMouseIsLocked() && g_MenuMouseControl) {
-			inputs.mousemoved = inputMouseGetPosition(&inputs.mousex, &inputs.mousey);
 			inputs.mousescroll = inputKeyPressed(VK_MOUSE_WHEEL_DN) - inputKeyPressed(VK_MOUSE_WHEEL_UP);
+			inputs.mousemoved = inputMouseGetPosition(&inputs.mousex, &inputs.mousey) || inputs.mousescroll;
 			// aspect correct the X
 			const f32 cx = ((f32)inputs.mousex - (f32)(SCREEN_WIDTH_LO / 2)) * (videoGetAspect() / SCREEN_ASPECT);
 			inputs.mousex = (f32)(SCREEN_WIDTH_LO / 2) + cx;

--- a/src/game/menuitem.c
+++ b/src/game/menuitem.c
@@ -2608,6 +2608,12 @@ bool menuitemSliderTick(struct menuitem *item, struct menudialog *dialog, struct
 				index = 0;
 			}
 
+#ifndef PLATFORM_N64
+			if (g_MenuUsingMouse && inputs->mousescroll) {
+				index += -inputs->mousescroll;
+			}
+#endif
+
 			if ((item->flags & MENUITEMFLAG_SLIDER_FAST) == 0
 					&& g_Menus[g_MpPlayerNum].xrepeatmode == MENUREPEATMODE_SLOW) {
 				index = index + inputs->leftright;

--- a/src/game/menuitem.c
+++ b/src/game/menuitem.c
@@ -2610,7 +2610,12 @@ bool menuitemSliderTick(struct menuitem *item, struct menudialog *dialog, struct
 
 #ifndef PLATFORM_N64
 			if (g_MenuUsingMouse && inputs->mousescroll) {
-				index += -inputs->mousescroll;
+				if ((item->flags & MENUITEMFLAG_SLIDER_FAST) == 0) {
+					index += -inputs->mousescroll;
+				} else {
+					s32 mult = item->param3 / 40;
+					index += -inputs->mousescroll * (mult ? mult : 1);
+				}
 			}
 #endif
 

--- a/src/game/menuitem.c
+++ b/src/game/menuitem.c
@@ -2559,7 +2559,7 @@ bool menuitemSliderTick(struct menuitem *item, struct menudialog *dialog, struct
 
 	if ((tickflags & MENUTICKFLAG_ITEMISFOCUSED)) {
 #ifndef PLATFORM_N64
-		if (g_MenuUsingMouse && inputs->select) {
+		if (g_AllowMouseHeld && g_MenuUsingMouse && (inputs->select || inputs->mouseheld)) {
 			// handle mouse
 			struct menudialog *dialog = g_Menus[g_MpPlayerNum].curdialog;
 			if (dialog) {
@@ -2568,24 +2568,27 @@ bool menuitemSliderTick(struct menuitem *item, struct menudialog *dialog, struct
 				const s32 size = right - left;
 				const s32 delta = inputs->mousex - left;
 				if (delta >= -8 && delta <= size + 8) {
-					index = (delta / (f32)size) * item->param3;
-					if (index < 0) {
-						index = 0;
-					}
-					if (index > item->param3) {
-						index = item->param3;
-					}
-					if (item->handler) {
-						if ((item->flags & MENUITEMFLAG_SLIDER_DEFERRED) &&
-							(tickflags & MENUTICKFLAG_DIALOGISDIMMED)) {
-							deferredindex = index;
-						} else {
-							item->handler(MENUOP_GET, item, &handlerdata);
-							handlerdata.slider.value = index;
-							item->handler(MENUOP_SET, item, &handlerdata);
+					if ((tickflags & MENUTICKFLAG_DIALOGISDIMMED) == 0) {
+						g_MouseDimmedMode = true;
+					} else {
+						index = (delta / (f32)size) * item->param3;
+						if (index < 0) {
+							index = 0;
 						}
+						if (index > item->param3) {
+							index = item->param3;
+						}
+						if (item->handler) {
+							if (item->flags & MENUITEMFLAG_SLIDER_DEFERRED) {
+								deferredindex = index;
+							} else {
+								item->handler(MENUOP_GET, item, &handlerdata);
+								handlerdata.slider.value = index;
+								item->handler(MENUOP_SET, item, &handlerdata);
+							}
+						}
+						return true;
 					}
-					return true;
 				}
 			}
 		}
@@ -2702,7 +2705,8 @@ bool menuitemSliderTick(struct menuitem *item, struct menudialog *dialog, struct
 				}
 			}
 
-			if (inputs->select) {
+			if (inputs->select || g_MouseEndDeferredSlider) {
+				g_MouseEndDeferredSlider = false;
 				if (item->flags & MENUITEMFLAG_SLIDER_DEFERRED) {
 					deferredindex = -1;
 					if (item->handler) {

--- a/src/include/data.h
+++ b/src/include/data.h
@@ -539,6 +539,9 @@ extern const struct weathercfg *g_CurWeatherConfig;
 
 extern s32 g_MenuUsingMouse;
 extern s32 g_MenuKeyboardPlayer;
+extern s32 g_AllowMouseHeld;
+extern s32 g_MouseDimmedMode;
+extern s32 g_MouseEndDeferredSlider;
 
 extern f32 g_ViShakeIntensityMult;
 extern u32 g_TexFilter2D;

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -4996,8 +4996,9 @@ struct menuinputs {
 	/*0x10*/ s32 unk10;
 	/*0x14*/ u8 unk14;
 #ifndef PLATFORM_N64
-	/*0x15*/ u8 mousemoved;
-	/*0x16*/ s8 mousescroll;
+	/*0x15*/ u8 mouseheld;
+	/*0x16*/ u8 mousemoved;
+	/*0x17*/ s8 mousescroll;
 	/*0x18*/ s32 mousex;
 	/*0x1c*/ s32 mousey;
 #endif


### PR DESCRIPTION
https://github.com/user-attachments/assets/403f5c0c-2685-41c8-bc09-743e82a45936

### Main features
* Adjusting sliders with mousescroll
* Dragging sliders with the mouse

Additional code was introduced to handle edge cases. Sliders are always dimmed when clicked with the mouse, now. When the mouse button is release, dimmed mode is turned off. This was done to prevent adjacent slider items from being accidentally modified by moving the mouse over them with the left mouse button held down, as well as to allow proper functioning of deferred sliders (see below) with the mouse.

It's still possible to enter dimmed mode the regular way; you just need to click on the slider name and not its value. Though I forgot to showcase it in the video, dragging the slider with the mouse in regular dimmed mode will not cause it to leave dimmed mode until you click on the name again. Mousescroll can only change the slider while in regular dimmed mode.

This will stay as a draft until #538 is merged because:
1. It will otherwise cause merge conflicts
2. To be feature-complete, it still needs work to accommodate deferred sliders, a slider mode introduced in 538 