### PR TITLE
Make mouse aim speed resolution-independent

### DIFF
--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -2204,8 +2204,10 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 #ifndef PLATFORM_N64
 		if (allowmcross) {
 			// joystick is inactive, move crosshair using the mouse
-			const f32 xscale = PLAYER_EXTCFG().mouseaimspeedx * 320.f / (f32)videoGetWidth();
-			const f32 yscale = PLAYER_EXTCFG().mouseaimspeedy * 240.f / (f32)videoGetHeight();
+			const f32 xcoeff = 320.f / 1080.f;
+			const f32 ycoeff = 240.f / 1080.f;
+			const f32 xscale = (PLAYER_EXTCFG().mouseaimspeedx * xcoeff) / videoGetAspect();
+			const f32 yscale = PLAYER_EXTCFG().mouseaimspeedy * ycoeff;
 			f32 x = g_Vars.currentplayer->swivelpos[0] + movedata.freelookdx * xscale;
 			f32 y = g_Vars.currentplayer->swivelpos[1] + movedata.freelookdy * yscale;
 			x = (x < -1.f) ? -1.f : ((x > 1.f) ? 1.f : x);


### PR DESCRIPTION
I feel it's better not to tie the mouse aim speed to the resolution. Unfortunately, this change means that the aim speed will need to be readjusted by everyone who uses it, if this PR is merged; I'm really sorry and hate to cause grievances. On the other hand, having to change the sensitivity whenever the resolution is changed is far more cumbersome.

Those `0.10f` can be changed to whatever you feel is more appropriate. I imagine most people play this game using a 1080p monitor (but really, whatever the most common size is is what should be used), so maybe this is better?:
```c
const f32 xscale = PLAYER_EXTCFG().mouseaimspeedx * 320.f / 1080.f;
const f32 yscale = PLAYER_EXTCFG().mouseaimspeedy * 240.f / 1920.f;
```