### PR TITLE
Allow typing with keyboard in menuitemKeyboard

### DIFF
--- a/port/include/input.h
+++ b/port/include/input.h
@@ -21,6 +21,7 @@ enum virtkey {
 	VK_KEYBOARD_BEGIN = 0,
 	VK_RETURN = 40,
 	VK_ESCAPE = 41,
+	VK_BACKSPACE = 42,
 	VK_DELETE = 76,
 
 	/* same order as SDL mouse buttons */
@@ -87,6 +88,14 @@ enum mouselockmode {
 	MLOCK_AUTO = 2
 };
 
+enum keymod {
+	/* same order as SDL keymods */
+	KM_LSHIFT = 0x0001,
+	KM_RSHIFT = 0x0002,
+	KM_CAPS = 0x2000,
+	KM_SHIFT = KM_LSHIFT | KM_RSHIFT
+};
+
 // returns bitmask of connected controllers or -1 if failed
 s32 inputInit(void);
 
@@ -139,6 +148,9 @@ s32 inputAssignController(s32 cidx, s32 id);
 // vk is a value from the virtkey enum above
 s32 inputKeyPressed(u32 vk);
 s32 inputKeyJustPressed(u32 vk);
+
+// same as inputKeyJustPressed but returns true again if key repeat activates
+s32 inputKeyJustPressedWithRepeat(u32 vk);
 
 // idx is controller index, contbtn is one of the CONT_ constants
 s32 inputButtonPressed(s32 idx, u32 contbtn);
@@ -216,5 +228,19 @@ s32 inputAutoLockMouse(s32 wantlock);
 
 // show/hide mouse cursor; if mouse lock is on the cursor is always hidden
 void inputMouseShowCursor(s32 show);
+
+// enables/disables/queries text input event processing, respectively
+void inputStartTextInput(void);
+void inputStopTextInput(void);
+s32 inputIsTextInputActive(void);
+
+// fills textInputBuffer with textInput chars
+void inputSetTextInput(char *textInput);
+
+// returns pointer to textInputBuffer
+char *inputGetTextInput(void);
+
+// returns keymod values
+u32 inputGetModState(void);
 
 #endif

--- a/src/game/menuitem.c
+++ b/src/game/menuitem.c
@@ -4701,7 +4701,7 @@ Gfx *menuitemOverlay(Gfx *gdl, s16 x, s16 y, s16 x2, s16 y2, struct menuitem *it
 s32 menuitemGetTop(struct menuitem *item, struct menudialog *dialog)
 {
 	struct menu *menu = &g_Menus[g_MpPlayerNum];
-	s32 dtop = dialog->y + LINEHEIGHT + 1;
+	s32 dtop = dialog->y + LINEHEIGHT + 1 + dialog->dstscroll;
 
 	for (s32 i = 0; i < dialog->numcols; ++i) {
 		const s32 colindex = i + dialog->colstart;

--- a/src/include/data.h
+++ b/src/include/data.h
@@ -554,6 +554,8 @@ extern s32 g_TickExtraSleep;
 extern s32 g_MusicDisableMpDeath;
 extern s32 g_BgunGeMuzzleFlashes;
 extern s32 g_FileAutoSelect;
+extern s32 g_MenuTypeWithKeyboard;
+extern s32 g_MenuTypeBackspace;
 
 #define PLAYER_EXTCFG() g_PlayerExtCfg[g_Vars.currentplayerstats->mpindex & 3]
 #define PLAYER_DEFAULT_FOV (PLAYER_EXTCFG().fovy)


### PR DESCRIPTION
https://github.com/user-attachments/assets/ada6d54b-cf66-4cf1-aa30-53680111a44d

Closes #489.

### Features
* Togglable between text input and traditional input modes
* Utilizes SDL's text input event handling.
* Filters input to only accept characters available to the on-screen keyboard.
* Synchronizes `capslock` state with the OS (including shift). This means `CAPS` on the on-screen keyboard becomes disabled since it is managed under the hood.
* Plays sound effects the same way as the traditional input. eg. entering/deleting a character, toggling `CAPS`, etc...
* Exhibits all the same quirks as the traditional input, such as playing char entry sound effects when the screen space to enter a char has become exhausted but the buffer's limit hasn't been reached.
* Disables and hides itself if the player is using a controller. Originally, it disabled and dimmed the text if using a controller, but I felt it was more appropriate to actually remove it from the dialog, in that case.

### Issues
* "TYPE WITH KEYBOARD" is a non-localized string.
* `backspace` key will repeat at the game's framerate, as opposed to every other key, which will repeat at the OS's repeat interval.
* Holding `capslock` will cause it to "repeat" and can desync its state from the hardware. I tried pretty hard to fix this but it seems to be intractable.