### PR TITLE
Profile config extensions

### DIFF
--- a/port/include/config.h
+++ b/port/include/config.h
@@ -5,10 +5,41 @@
 #define CONFIG_FNAME "pd.ini"
 #define CONFIG_PATH "$S/" CONFIG_FNAME
 
+
+#define CONFIG_MAX_SECNAME 128
+#define CONFIG_MAX_KEYNAME 256
+#define CONFIG_MAX_SETTINGS 256 * 8
+
+typedef enum {
+	CFG_NONE,
+	CFG_S32,
+	CFG_F32,
+	CFG_U32,
+	CFG_STR,
+	CFG_U8
+} configtype;
+
+struct configentry {
+	char key[CONFIG_MAX_KEYNAME + 1];
+	s32 seclen;
+	configtype type;
+	void *ptr;
+	union {
+		struct { f32 min_f32, max_f32; };
+		struct { s32 min_s32, max_s32; };
+		struct { u32 min_u32, max_u32; };
+		struct { u8 min_u8, max_u8; };
+		u32 max_str;
+	};
+};
+
+extern struct configentry settings[CONFIG_MAX_SETTINGS];
+
 void configInit(void);
 
 // loads config from file (path extensions such as ! apply)
 s32 configLoad(const char *fname);
+s32 configLoadKey(const char *fname, char *key);
 
 // saves config to file (path extensions such as ! apply)
 s32 configSave(const char *fname);
@@ -19,3 +50,14 @@ void configRegisterInt(const char *key, s32 *var, s32 min, s32 max);
 void configRegisterUInt(const char* key, u32* var, u32 min, u32 max);
 void configRegisterFloat(const char *key, f32 *var, f32 min, f32 max);
 void configRegisterString(const char *key, char *var, u32 maxstr);
+
+// player save stuff
+struct configentry *configFindPlayerEntry(s32 player, const char *key);
+struct configentry *configFindOrAddPlayerEntry(s32 player, const char *key);
+void configSetPlayerEntry(s32 player, const char *key, const char *val);
+s32 getPlayerConfigSlug(s32 playernum, char *out, char* key);
+void configRegisterU8Int(const char *key, u8 *var, u32 min, u32 max);
+
+struct configentry *configFindEntryByPtr(void *ptr);
+
+s32 getConfigIndexFromDB(u16 deviceserial, s32 fileid);

--- a/src/game/filemgr.c
+++ b/src/game/filemgr.c
@@ -871,10 +871,12 @@ bool filemgrAttemptOperation(s32 device, bool closeonsuccess)
 			filemgrHandleSuccess();
 		}
 
+		// Success dialog: Cool!
 		if (showfilesaved && errnum == 0) {
 			menuPushDialog(&g_FilemgrFileSavedMenuDialog);
 		}
 	} else {
+		// file load
 		if (errnum == 0) {
 			filemgrHandleSuccess();
 		}

--- a/src/game/lv.c
+++ b/src/game/lv.c
@@ -2443,6 +2443,8 @@ void lvStop(void)
 #if VERSION >= VERSION_NTSC_1_0
 	menuStop();
 #endif
+	updateGuids();
+	mpExtendedProfileRegisterBlank();
 }
 
 void lvCheckPauseStateChanged(void)

--- a/src/game/mplayer/mplayer.c
+++ b/src/game/mplayer/mplayer.c
@@ -28,6 +28,8 @@
 #include "lib/lib_317f0.h"
 #include "data.h"
 #include "types.h"
+#include "config.h"
+#include "input.h"
 
 // bss
 struct chrdata *g_MpAllChrPtrs[MAX_MPCHRS];
@@ -43,6 +45,8 @@ struct bossfile g_BossFile;
 u32 var800acc1c;
 struct mplockinfo g_MpLockInfo;
 struct modeldef *var800acc28[18];
+
+s32 g_NumProfiles = 0;
 
 // Forward declaractions
 struct mpweaponset g_MpWeaponSets[12];
@@ -132,12 +136,167 @@ struct mpweapon g_MpWeapons[NUM_MPWEAPONS] = {
 	.crosshairhealth = CROSSHAIR_HEALTH_OFF, \
 }
 
-struct extplayerconfig g_PlayerExtCfg[MAX_PLAYERS] = { 
+struct extplayerconfig g_PlayerExtCfg[MAX_PLAYERS] = {
 	PLAYER_EXT_CFG_DEFAULT,
 	PLAYER_EXT_CFG_DEFAULT,
 	PLAYER_EXT_CFG_DEFAULT,
 	PLAYER_EXT_CFG_DEFAULT,
 };
+
+
+#define PLAYER_EXT_PROFILE_DEFAULT { \
+	.fileguid = 0, \
+	.handicap = 0x80, \
+};
+
+struct extplayerprofile g_ExtendedProfiles[CONFIG_MAX_PROFILES];
+
+struct extprofileproperty {
+	configtype type;
+	char *name;
+	union{
+		struct {
+			u8 initialvalue_u8;
+			s8 min_u8;
+			s8 max_u8;
+		};
+		struct {
+			s32 min_s32;
+			s32 initialvalue_s32;
+			s32 max_s32;
+		};
+		struct {
+			u32 max_u32;
+			u32 min_u32;
+			u32 initialvalue_u32;
+		};
+		struct {
+			f32 max_f32;
+			f32 min_f32;
+			f32 initialvalue_f32;
+		};
+		struct {
+			char initialvalue_str[128];
+			u32 max_str;
+		};
+	};
+	void (*initfunc)(s32, s32);
+};
+
+struct extprofileproperty g_ExtendedProfileProperties[] = {
+}; // these must be in the same order as the extendedprofile struct, ignoring the fileguid
+
+static inline s32 getExtendedProfileIndexFromFileGuid(const struct fileguid* fileguid)
+{
+	s32 i;
+
+	for (i = 0; i < g_NumProfiles; i++) {
+		if (g_ExtendedProfiles[i].fileguid.fileid == fileguid->fileid &&\
+				g_ExtendedProfiles[i].fileguid.deviceserial == fileguid->deviceserial) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+static inline s32 mpExtendedProfileAdd(struct fileguid *fileguid)
+{
+	s32 index = getExtendedProfileIndexFromFileGuid(fileguid);
+
+	if (index < 0) {
+		index = g_NumProfiles;
+
+		if (g_NumProfiles < CONFIG_MAX_PROFILES) {
+			g_NumProfiles++;
+		}
+
+		g_ExtendedProfiles[index] = (struct extplayerprofile)PLAYER_EXT_PROFILE_DEFAULT;
+		g_ExtendedProfiles[index].fileguid.deviceserial = fileguid->deviceserial;
+		g_ExtendedProfiles[index].fileguid.fileid = fileguid->fileid;
+	}
+
+	return index;
+}
+
+static inline s32 mpPlayerGetIndexFromFileGuid(struct fileguid *fileguid)
+{
+	s32 i;
+
+	for (i = 0; i < MAX_PLAYERS; i++) {
+		if (g_PlayerConfigsArray[i].fileguid.fileid == fileguid->fileid &&\
+				g_PlayerConfigsArray[i].fileguid.deviceserial == fileguid->deviceserial) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+static inline s32 mpExtendedProfileRegister(struct fileguid *fileguid, s32 arg0)
+{
+	s32 i;
+
+	char *playerslug = 0;
+	char playerbuf[128];
+
+	if (arg0 & 1) {
+		sprintf(playerbuf, "MpPlayer.%x-%x", fileguid->deviceserial, fileguid->fileid);
+		playerslug = playerbuf;
+	}
+
+	s32 configindex = mpExtendedProfileAdd(fileguid);
+
+	s32 playernum = mpPlayerGetIndexFromFileGuid(fileguid);
+
+	for (i = 0; i < ARRAYCOUNT(g_ExtendedProfileProperties); i++) {
+		char key[128];
+		sprintf(key, "%s.%s", playerslug, g_ExtendedProfileProperties[i].name);
+
+		switch (g_ExtendedProfileProperties[i].type) {
+		case CFG_U8:
+			if (playerslug) {
+				g_ExtendedProfiles[configindex].ptr[i+1] = (extplayerprop)g_ExtendedProfileProperties[i].initialvalue_u8;
+				configRegisterU8Int(key, (u8*)&g_ExtendedProfiles[configindex].ptr[i+1].u8, g_ExtendedProfileProperties[i].min_u8, g_ExtendedProfileProperties[i].max_u8);
+			}
+			if (g_ExtendedProfileProperties[i].initfunc) g_ExtendedProfileProperties[i].initfunc(configindex, playernum);
+			break;
+		case CFG_S32:
+			if (playerslug) {
+				g_ExtendedProfiles[configindex].ptr[i+1] = (extplayerprop)g_ExtendedProfileProperties[i].initialvalue_s32;
+				configRegisterInt(key, (s32*)&g_ExtendedProfiles[configindex].ptr[i+1].s32, g_ExtendedProfileProperties[i].min_s32, g_ExtendedProfileProperties[i].max_s32);
+			}
+			if (g_ExtendedProfileProperties[i].initfunc) g_ExtendedProfileProperties[i].initfunc(configindex, playernum);
+			break;
+		case CFG_U32:
+			if (playerslug) {
+				g_ExtendedProfiles[configindex].ptr[i+1] = (extplayerprop)g_ExtendedProfileProperties[i].initialvalue_u32;
+				configRegisterUInt(key, (u32*)&g_ExtendedProfiles[configindex].ptr[i+1].u32, g_ExtendedProfileProperties[i].min_u32, g_ExtendedProfileProperties[i].max_u32);
+			}
+			if (g_ExtendedProfileProperties[i].initfunc) g_ExtendedProfileProperties[i].initfunc(configindex, playernum);
+			break;
+		case CFG_F32:
+			if (playerslug) {
+				g_ExtendedProfiles[configindex].ptr[i+1] = (extplayerprop)g_ExtendedProfileProperties[i].initialvalue_f32;
+				configRegisterFloat(key, (f32*)&g_ExtendedProfiles[configindex].ptr[i+1].f32, g_ExtendedProfileProperties[i].min_f32, g_ExtendedProfileProperties[i].max_f32);
+			}
+			if (g_ExtendedProfileProperties[i].initfunc) g_ExtendedProfileProperties[i].initfunc(configindex, playernum);
+			break;
+		case CFG_STR:
+			if (playerslug) {
+				g_ExtendedProfiles[configindex].ptr[i+1] = (extplayerprop)g_ExtendedProfileProperties[i].initialvalue_str;
+				configRegisterString(key, (char*)g_ExtendedProfiles[configindex].ptr[i+1].string, sizeof(g_ExtendedProfiles[configindex].ptr[i]));
+			}
+			if (g_ExtendedProfileProperties[i].initfunc) g_ExtendedProfileProperties[i].initfunc(configindex, playernum);
+			break;
+		}
+		if (playerslug) configLoadKey(CONFIG_PATH, key);
+	}
+
+	return configindex;
+}
+
+
 
 #endif
 
@@ -222,6 +381,8 @@ void mpStartMatch(void)
 
 	g_Vars.perfectbuddynum = 1;
 }
+
+
 
 void mpReset(void)
 {
@@ -416,6 +577,30 @@ void func0f187fec(void)
 	g_MpSetup.teamscorelimit = 19;
 }
 
+static inline void processGuids()
+{
+	for (s32 i = 0; i < g_NumGuidsToProcess; i++) {
+		printf("Processing guid %x\n", g_GuidsToProcess[i].fileid);
+		mpExtendedProfileRegister(&g_GuidsToProcess[i], 1);
+	}
+	g_NumGuidsToProcess = 0;
+}
+
+void mpExtendedProfileRegisterBlank(void)
+{
+	struct fileguid fileguid = {0, 0};
+	mpExtendedProfileRegister(&fileguid, 1);
+}
+void updateNewGuids(s32 arg0)
+{
+	processGuids();
+}
+
+void updateGuids(void)
+{
+	processGuids();
+}
+
 void mpPlayerSetDefaults(s32 playernum, bool autonames)
 {
 	s32 i;
@@ -446,6 +631,7 @@ void mpPlayerSetDefaults(s32 playernum, bool autonames)
 		| OPTION_ALWAYSSHOWTARGET
 		| OPTION_SHOWZOOMRANGE;
 
+	updateNewGuids(autonames);
 	g_PlayerConfigsArray[playernum].handicap = 128;
 
 	switch (playernum) {
@@ -3616,6 +3802,29 @@ void mpplayerfileGetOverview(char *arg0, char *name, u32 *playtime)
 	*playtime = savebufferReadBits(&buffer, 28);
 }
 
+// save: this should be called immediately after updating the file guid / device serial
+// load: this should be called immediately after loading the wad
+static inline void updateExtendedMpProfileOnFileOperation(s32 playernum)
+{
+	s32 configindex = getExtendedProfileIndexFromFileGuid(&g_PlayerConfigsArray[playernum].fileguid);
+
+	if (configindex > 0) {
+		// old config is still saved to its own index, if any
+		// we just need to calculate the index of the config in the global array
+		// for the player we just loaded
+		g_PlayerConfigsArray[playernum].configindex = configindex;
+		configindex = mpExtendedProfileRegister(&g_PlayerConfigsArray[playernum].fileguid, 0);
+		g_PlayerConfigsArray[playernum].configindex = configindex;
+
+	} else {
+		// register new entry
+		// need table with cfgtype, slugname, defaultvalue for every extended profile property
+		// so the appriate init function can be called and config file setup
+		configindex = mpExtendedProfileRegister(&g_PlayerConfigsArray[playernum].fileguid, 1);
+		g_PlayerConfigsArray[playernum].configindex = configindex;
+	}
+}
+
 s32 mpplayerfileSave(s32 playernum, s32 device, s32 fileid, u16 deviceserial)
 {
 	s32 ret;
@@ -3634,6 +3843,7 @@ s32 mpplayerfileSave(s32 playernum, s32 device, s32 fileid, u16 deviceserial)
 		if (ret == 0) {
 			g_PlayerConfigsArray[playernum].fileguid.fileid = newfileid;
 			g_PlayerConfigsArray[playernum].fileguid.deviceserial = deviceserial;
+			updateExtendedMpProfileOnFileOperation(playernum);
 			return 0;
 		}
 
@@ -3649,6 +3859,10 @@ s32 mpplayerfileLoad(s32 playernum, s32 device, s32 fileid, u16 deviceserial)
 	s32 ret;
 	struct savebuffer buffer;
 
+	// iterate through g_GuidsToProcess and check if the fileid is already loaded
+	// the counter is g_NumGuidsToProcess
+	processGuids();
+
 	if (device >= 0) {
 		savebufferClear(&buffer);
 
@@ -3660,6 +3874,8 @@ s32 mpplayerfileLoad(s32 playernum, s32 device, s32 fileid, u16 deviceserial)
 
 			mpplayerfileLoadWad(playernum, &buffer, 1);
 			func0f0d54c4(&buffer);
+
+			updateExtendedMpProfileOnFileOperation(playernum);
 
 			g_PlayerConfigsArray[playernum].handicap = 0x80;
 			return 0;

--- a/src/include/bss.h
+++ b/src/include/bss.h
@@ -295,6 +295,8 @@ extern s32 g_JpnMaxCacheItems;
 extern s32 var8009d370jf;
 #ifndef PLATFORM_N64
 extern bool g_ValidGbcRomFound;
+extern struct fileguid g_GuidsToProcess[CONFIG_MAX_PROFILES];
+extern u32 g_NumGuidsToProcess;
 #endif
 
 #endif

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -1696,7 +1696,7 @@
 
 #ifndef PLATFORM_N64
 #define MENUITEMTYPE_COLORBOX    0x1b
-#endif 
+#endif
 
 #define MENUMODELFLAG_HASSCALE    0x01
 #define MENUMODELFLAG_HASPOSITION 0x02
@@ -4752,6 +4752,9 @@ enum weaponnum {
 #define CROSSHAIR_HEALTH_ON_WHITE 2
 
 #define EXTRA_SLEEP_TIME 1000LL // 100us
+
+// if controller pak-like support was added and everyone had 4 profiles, this is twice the max
+#define CONFIG_MAX_PROFILES ((MAX_PLAYERS * 4) * 2)
 
 #endif
 

--- a/src/include/data.h
+++ b/src/include/data.h
@@ -532,6 +532,8 @@ extern struct menudialogdef g_HangarListMenuDialog;
 #ifndef PLATFORM_N64
 
 extern struct extplayerconfig g_PlayerExtCfg[MAX_PLAYERS];
+extern struct extplayerprofile g_PlayerProfiles[CONFIG_MAX_PROFILES];
+extern s32 g_NumProfiles;
 
 extern struct weathercfg g_WeatherConfig[WEATHERCFG_MAX_STAGES];
 extern const struct weathercfg g_DefaultWeatherConfig;

--- a/src/include/game/mplayer/mplayer.h
+++ b/src/include/game/mplayer/mplayer.h
@@ -122,5 +122,8 @@ s32 mpsetupfileSave(s32 device, s32 filenum, u16 deviceserial);
 s32 mpsetupfileLoad(s32 device, s32 filenum, u16 deviceserial);
 void func0f18e558(void);
 struct modeldef *func0f18e57c(s32 index, s32 *headnum);
+void updateNewGuids(s32 arg0);
+void updateGuids(void);
+void mpExtendedProfileRegisterBlank(void);
 
 #endif

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -4,6 +4,7 @@
 #include <PR/ultrasched.h>
 #include "n_libaudio.h"
 #include "constants.h"
+#include "config.h"
 #include "lang.h"
 #include "pads.h"
 #include "tiles.h"
@@ -4050,6 +4051,7 @@ struct mpplayerconfig {
 	/*0x96*/ u8 newtitle;
 	/*0x97*/ u8 gunfuncs[6];
 	/*0x9d*/ u8 handicap;
+	s32 configindex;
 };
 
 struct mpbotconfig {
@@ -6153,6 +6155,26 @@ struct extplayerconfig {
 	u32 crosshairsize;
 	s32 crosshairhealth;
 };
+
+typedef union {
+	struct fileguid fileguid;
+	u8 u8;
+	s32 s32;
+	f32 f32;
+	u32 u32;
+	char *string;
+} extplayerprop;
+
+struct extplayerprofile {
+	union {
+		struct {
+			struct fileguid fileguid;
+			u8 handicap;
+		};
+		extplayerprop ptr[2];
+	};
+};
+
 
 #endif
 

--- a/src/lib/varsinit.c
+++ b/src/lib/varsinit.c
@@ -10,6 +10,9 @@ u32 var8009e6b0[4];
 
 struct g_vars g_Vars;
 
+struct fileguid g_GuidsToProcess[CONFIG_MAX_PROFILES] = {};
+u32 g_NumGuidsToProcess = 0;
+
 void varsInit(void)
 {
 	g_Vars.diffframe60f = 1;


### PR DESCRIPTION
# Motivation

Extend the config file properties to bind properties the save files themselves. This Proof of Concept is setup for MP Profiles (Combat Simulator or CS) and to bind the `Handicap` setting directly to the profile itself without modifying the binary save file.

# Approach - Profile Extensions Proof of Concept

Introduced new structures (`struct extplayerprofile` and `struct extplayerprop`) to encapsulate extended player profile properties. A save-specific key prefix is generated  as : `MpPlayer.x%-x%.`, `fileguid.deviceserial, fileguid.fileid` This approach can be extended to other save file types (game file, mp setup, bss, perfect head) and/or to associate mod-specific properties with a particular save type.

During config file initialization: `fileguid` like slugs are detected from the ini and a `struct configentry` is added to `settings` and the pointer is registered to an internal extended player profile table `struct extplayerprofile` as a new element of `g_ExtendedPlayerProfiles.` 

When the CS file is actually loaded for the first time during the session `mpExtendedProfileRegister` is called w/ a parameter to actually bind the config entry to the extended profile store. 

During CS file transitions the initfunc for all properties is called to ensure the right values are bound to the extended profile store / config entry. 

Removed uncalled  functions and hooked in config extensions into MP save / loading flow.

# Related changes

- PR to rename save-related function: https://github.com/fgsfdsfgs/perfect_dark/pull/561
- PR to setup `Handicap` as a extended profile entry: https://github.com/fgsfdsfgs/perfect_dark/pull/562
