### PR TITLE
Fix to enable Friendly Fire option in Challenge

### DIFF
--- a/src/game/challenge.c
+++ b/src/game/challenge.c
@@ -687,6 +687,12 @@ void challengeApply(void)
 	for (i = 0; i < MAX_PLAYERS; i++) {
 		g_PlayerConfigsArray[i].base.team = 0;
 	}
+
+#ifndef PLATFORM_N64
+	// Enable Friendly Fire option
+	g_MpSetup.options |= MPOPTION_FRIENDLYFIRE;
+#endif
+
 }
 
 s32 challengeRemovePlayerLock(void)


### PR DESCRIPTION
Friendly Fire enabled: Can kill teammates (combat default)
Friendly Fire disabled: Can't kill teammates

The default setting for the challenge is Friendly Fire disabled and you cannot kill teammates, I fixed it so that you can kill them.