### PR TITLE
Flatpak x86_64

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -266,7 +266,7 @@ jobs:
   build-flatpak-bundle:
     name: "Build flatpak bundle"
     runs-on: ubuntu-latest
-    needs: [build-i686-linux, build-x86_64-linux]
+    needs: [build-x86_64-linux]
     container:
       image: bilelmoussaoui/flatpak-github-actions:freedesktop-23.08
       options: --privileged
@@ -274,7 +274,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
-        name: pd-i686-linux
+        name: pd-x86_64-linux
         path: dist/linux/bin/
 
     - uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/dist/linux/io.github.fgsfdsfgs.perfect_dark.desktop
+++ b/dist/linux/io.github.fgsfdsfgs.perfect_dark.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Perfect Dark
 Comment=Modern source port of Perfect Dark
-Exec=pd
+Exec=io.github.fgsfdsfgs.perfect_dark.sh
 Icon=io.github.fgsfdsfgs.perfect_dark
 Terminal=false
 Type=Application

--- a/dist/linux/io.github.fgsfdsfgs.perfect_dark.sh
+++ b/dist/linux/io.github.fgsfdsfgs.perfect_dark.sh
@@ -11,14 +11,14 @@ done
 # Default to pd as executable but switch to jpn/pal if the NTSC rom
 # is missing but JPN/PAL are present.
 # TODO: Other arch
-executable="pd.i686"
+executable="pd.x86_64"
 if [ -f ${XDG_DATA_HOME}/roms/pd.ntsc-final.z64 ] | \
    [ -f ${XDG_DATA_HOME}/roms/pd.ntsc-1.0.z64 ]; then
-    executable="pd.i686"
+    executable="pd.x86_64"
 elif [ -f ${XDG_DATA_HOME}/roms/pd.jpn-final.z64 ]; then
-    executable="pd.jpn.i686"
+    executable="pd.jpn.x"
 elif [ -f ${XDG_DATA_HOME}/roms/pd.pal-final.z64 ]; then
-    executable="pd.pal.i686"
+    executable="pd.pal.x86_64"
 fi
 
 # If first parameter passed to this script is one of the pd executables,

--- a/dist/linux/io.github.fgsfdsfgs.perfect_dark.sh
+++ b/dist/linux/io.github.fgsfdsfgs.perfect_dark.sh
@@ -16,7 +16,7 @@ if [ -f ${XDG_DATA_HOME}/roms/pd.ntsc-final.z64 ] | \
    [ -f ${XDG_DATA_HOME}/roms/pd.ntsc-1.0.z64 ]; then
     executable="pd.x86_64"
 elif [ -f ${XDG_DATA_HOME}/roms/pd.jpn-final.z64 ]; then
-    executable="pd.jpn.x"
+    executable="pd.jpn.x86_64"
 elif [ -f ${XDG_DATA_HOME}/roms/pd.pal-final.z64 ]; then
     executable="pd.pal.x86_64"
 fi

--- a/dist/linux/io.github.fgsfdsfgs.perfect_dark.yaml
+++ b/dist/linux/io.github.fgsfdsfgs.perfect_dark.yaml
@@ -1,13 +1,11 @@
 app-id: io.github.fgsfdsfgs.perfect_dark
 runtime: org.freedesktop.Platform
-runtime-version: &runtime-version '23.08'
+runtime-version: "23.08"
 sdk: org.freedesktop.Sdk
 command: io.github.fgsfdsfgs.perfect_dark.sh
 
 finish-args:
-  # hardware 3D and controller access
   - --device=all
-  # X11 + XShm access
   - --share=ipc
   - --socket=x11
   # Audio
@@ -15,59 +13,16 @@ finish-args:
   # Enable network for multiplayer
   - --share=network
 
-# Parameters for 32-bit extensions
-x-gl-version: &gl-version '1.4'
-x-gl-versions: &gl-versions 23.08;1.4
-x-gl-merge-dirs: &gl-merge-dirs vulkan/icd.d;glvnd/egl_vendor.d;egl/egl_external_platform.d;OpenCL/vendors;lib/dri;lib/d3d;lib/gbm;vulkan/explicit_layer.d;vulkan/implicit_layer.d
-
-add-extensions:
-  org.freedesktop.Platform.Compat.i386:
-    directory: lib/i386-linux-gnu
-    version: '23.08'
-
-  org.freedesktop.Platform.GL32:
-    directory: lib/i386-linux-gnu/GL
-    version: *gl-version
-    versions: *gl-versions
-    subdirectories: true
-    no-autodownload: true
-    autodelete: false
-    add-ld-path: lib
-    merge-dirs: *gl-merge-dirs
-    download-if: active-gl-driver
-    enable-if: active-gl-driver
-    autoprune-unless: active-gl-driver
-
-  org.freedesktop.Platform.GL32.Debug:
-    directory: lib/debug/lib/i386-linux-gnu/GL
-    version: *gl-version
-    versions: *gl-versions
-    subdirectories: true
-    no-autodownload: true
-    merge-dirs: *gl-merge-dirs
-    enable-if: active-gl-driver
-    autoprune-unless: active-gl-driver
-
-  org.freedesktop.Platform.VAAPI.Intel.i386:
-    directory: lib/i386-linux-gnu/dri/intel-vaapi-driver
-    version: *runtime-version
-    versions: *runtime-version
-    autodelete: false
-    no-autodownload: true
-    add-ld-path: lib
-    download-if: have-intel-gpu
-    autoprune-unless: have-intel-gpu
-
 modules:
   - name: perfect_dark
     buildsystem: simple
     sources:
       - type: file
-        path: bin/pd.i686
+        path: bin/pd.x86_64
       - type: file
-        path: bin/pd.jpn.i686
+        path: bin/pd.jpn.x86_64
       - type: file
-        path: bin/pd.pal.i686
+        path: bin/pd.pal.x86_64
       - type: file
         path: io.github.fgsfdsfgs.perfect_dark.sh
       - type: file
@@ -78,13 +33,8 @@ modules:
         path: io.github.fgsfdsfgs.perfect_dark.desktop
     build-commands: []
     post-install:
-      # create extension mountpoints
-      - mkdir -p /app/lib/i386-linux-gnu
-      - mkdir -p /app/lib/i386-linux-gnu/GL
-      - mkdir -p /app/lib/debug/lib/i386-linux-gnu/GL
-      - mkdir -p /app/lib/i386-linux-gnu/dri/intel-vaapi-driver
-      # port
-      - install -Dm 755 -t /app/bin/ pd*
+      # Install the binaries
+      - install -Dm 755 -t /app/bin/ pd.*
       - install -Dm 755 ${FLATPAK_ID}.sh /app/bin/${FLATPAK_ID}.sh
       - install -Dm 644 ${FLATPAK_ID}.desktop /app/share/applications/${FLATPAK_ID}.desktop
       - install -Dm 644 ${FLATPAK_ID}.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml


### PR DESCRIPTION
Drop flatpak i686, default to x86_64.

There is hardly sense in deploying i686 flatpak, as an OS with flatpak installed will almost definitely be recent x86_64. It could be aarch64 too, I can attempt to support that in the next PR.

Otherwise, it works. I just finished the game using this same binary.