### PR TITLE
Mouse Sensitivity follows id Tech/Source sens scale

### DIFF
--- a/port/src/input.c
+++ b/port/src/input.c
@@ -1239,32 +1239,28 @@ void inputMouseGetRawDelta(s32 *dx, s32 *dy)
 	if (dy) *dy = mouseDY;
 }
 
-void inputMouseGetScaledDelta(f32 *dx, f32 *dy)
+void inputMouseGetScaledDelta(f32* dx, f32* dy)
 {
-	f32 mdx, mdy;
-	if (mouseLocked) {
-		mdx = mouseSensX * (f32)mouseDX / 159.2f;
-		mdy = mouseSensY * (f32)mouseDY / 159.2f;
-	} else {
-		mdx = 0.f;
-		mdy = 0.f;
-	}
-	if (dx) *dx = mdx;
-	if (dy) *dy = mdy;
+		f32 mdx = 0.f, mdy = 0.f;
+
+		if (mouseLocked) {
+				mdx = mouseSensX * ((f32)mouseDX / 3.5f) * 0.022f;
+				mdy = mouseSensY * ((f32)mouseDY / 3.5f) * 0.022f;
+		}
+		if (dx) *dx = mdx;
+		if (dy) *dy = mdy;
 }
 
-void inputMouseGetAbsScaledDelta(f32 *dx, f32 *dy)
+void inputMouseGetAbsScaledDelta(f32* dx, f32* dy)
 {
-	f32 mdx, mdy;
-	if (mouseLocked) {
-		mdx = fabsf(mouseSensX) * (f32)mouseDX / 159.2f;
-		mdy = fabsf(mouseSensY) * (f32)mouseDY / 159.2f;
-	} else {
-		mdx = 0.f;
-		mdy = 0.f;
-	}
-	if (dx) *dx = mdx;
-	if (dy) *dy = mdy;
+		f32 mdx = 0.f, mdy = 0.f;
+
+		if (mouseLocked) {
+				mdx = fabsf(mouseSensX) * ((f32)mouseDX / 3.5f) * 0.022f;
+				mdy = fabsf(mouseSensY) * ((f32)mouseDY / 3.5f) * 0.022f;
+		}
+		if (dx) *dx = mdx;
+		if (dy) *dy = mdy;
 }
 
 void inputMouseGetSpeed(f32 *x, f32 *y)

--- a/port/src/input.c
+++ b/port/src/input.c
@@ -88,8 +88,8 @@ static s32 mouseLockMode = MLOCK_AUTO;
 static u64 mouseCursorTime = 0;
 static s32 mouseShowCursor = 1;
 
-static f32 mouseSensX = 1.5f;
-static f32 mouseSensY = 1.5f;
+static f32 mouseSensX = 2.5f;
+static f32 mouseSensY = 2.5f;
 
 static s32 lastKey = 0;
 static char lastChar = 0;
@@ -1243,8 +1243,8 @@ void inputMouseGetScaledDelta(f32 *dx, f32 *dy)
 {
 	f32 mdx, mdy;
 	if (mouseLocked) {
-		mdx = mouseSensX * (f32)mouseDX / 100.0f;
-		mdy = mouseSensY * (f32)mouseDY / 100.0f;
+		mdx = mouseSensX * (f32)mouseDX / 159.2f;
+		mdy = mouseSensY * (f32)mouseDY / 159.2f;
 	} else {
 		mdx = 0.f;
 		mdy = 0.f;
@@ -1257,8 +1257,8 @@ void inputMouseGetAbsScaledDelta(f32 *dx, f32 *dy)
 {
 	f32 mdx, mdy;
 	if (mouseLocked) {
-		mdx = fabsf(mouseSensX) * (f32)mouseDX / 100.0f;
-		mdy = fabsf(mouseSensY) * (f32)mouseDY / 100.0f;
+		mdx = fabsf(mouseSensX) * (f32)mouseDX / 159.2f;
+		mdy = fabsf(mouseSensY) * (f32)mouseDY / 159.2f;
 	} else {
 		mdx = 0.f;
 		mdy = 0.f;

--- a/src/game/player.c
+++ b/src/game/player.c
@@ -3674,8 +3674,8 @@ void playerTick(bool arg0)
 						if (g_Vars.currentplayerstats && !optionsGetForwardPitch(g_Vars.currentplayerstats->mpindex)) {
 							mdy = -mdy;
 						}
-						sp178 += mdy * 0.00025f;
-						sp174 -= mdx * 0.00025f;
+						sp178 += mdy * 0.022f;
+						sp174 -= mdx * 0.022f;
 					}
 				}
 #endif

--- a/src/game/player.c
+++ b/src/game/player.c
@@ -3667,15 +3667,15 @@ void playerTick(bool arg0)
 					f32 mdx, mdy;
 					inputMouseGetScaledDelta(&mdx, &mdy);
 					if (mdx || mdy) {
-						mdx *= 48.f;
-						mdy *= 48.f;
+						mdx *= 0.022f;
+						mdy *= 0.022f;
 						mdx = (mdx < -128.f) ? -128.f : (mdx > 127.f) ? 127.f : mdx;
 						mdy = (mdy < -128.f) ? -128.f : (mdy > 127.f) ? 127.f : mdy;
 						if (g_Vars.currentplayerstats && !optionsGetForwardPitch(g_Vars.currentplayerstats->mpindex)) {
 							mdy = -mdy;
 						}
-						sp178 += mdy * 0.022f;
-						sp174 -= mdx * 0.022f;
+						sp178 += mdy;
+						sp174 -= mdx;
 					}
 				}
 #endif


### PR DESCRIPTION
During the work on https://github.com/fgsfdsfgs/perfect_dark/pull/591, I figured out a way to scale sensitivity code upwards to downwards while ensuring High Framerates works proper. (Although, this specific PR might need further testing on Framerates higher than 60fps)

 [A fellow Gyro Aimer dev (who helped on Shady Knights) suggested developers to adopt a standard to use id Tech/Quake's sensitivity scale (0.022)](https://x.com/HilariousCow/status/1831410090274124169)

As I wanna make it easier for Steam Deck and Steam Controller users to take advantage of Gyro To Mouse (upcoming Gyro behavior overhaul) and Flick Stick feature: I've decided to change the entire mouse delta scale.

This changes mouse sensitivity scale to mirror id Tech/Source engine's Mouse Sensitivity Scale (0.022, or 159.2f in this case). I tried my best to closely match the scaling from Quake by referencing Steam Input's 360 degrees camera turn.  (360/ 0.022 / 2.5 = ~6545)

With this commit: all they have to do is enable "Gyro To Mouse" and forget...assuming the player haven't change the mouse sensitivity since then...

At the same time: Joanna Dark can reuse her preferred mouse sensitivity from Quake or Counter-Strike during missions, no need to recalibrate it!