### PR TITLE
port: call `joyReset()` when changing controllers

### DIFF
--- a/port/src/optionsmenu.c
+++ b/port/src/optionsmenu.c
@@ -597,8 +597,10 @@ static MenuItemHandlerResult menuhandlerController(s32 operation, struct menuite
 		if (data->dropdown.value == 0) {
 			// unassign controller
 			inputAssignController(g_ExtMenuPlayer, -1);
+			joyReset();
 		} else if (data->dropdown.value <= numCtrls) {
 			inputAssignController(g_ExtMenuPlayer, ctrls[data->dropdown.value - 1]);
+			joyReset();
 		}
 		break;
 	case MENUOP_GETSELECTEDINDEX:

--- a/port/src/optionsmenu.c
+++ b/port/src/optionsmenu.c
@@ -10,6 +10,7 @@
 #include "game/menu.h"
 #include "game/gamefile.h"
 #include "game/player.h"
+#include "lib/joy.h"
 #include "video.h"
 #include "input.h"
 #include "config.h"


### PR DESCRIPTION
This needs to be called for controller reassignments to take effect in MP modes without restarting the game or going through "Change Agent"