### PR TITLE
rename `struct menudata.unk008|unk00c` properties

### DIFF
--- a/src/game/menu.c
+++ b/src/game/menu.c
@@ -3608,7 +3608,7 @@ void func0f0f820c(struct menudialogdef *dialogdef, s32 root)
 
 	g_MpPlayerNum = prevplayernum;
 
-	g_MenuData.unk008 = root;
+	g_MenuData.prevmenuroot = root;
 	g_MenuData.unk00c = dialogdef;
 }
 
@@ -3683,7 +3683,7 @@ void menuPushRootDialog(struct menudialogdef *dialogdef, s32 root)
 	g_Menus[g_MpPlayerNum].unk820 = 1;
 
 	g_MenuData.root = root;
-	g_MenuData.unk008 = -1;
+	g_MenuData.prevmenuroot = -1;
 	g_MenuData.unk5d5_02 = false;
 
 	if (root == MENUROOT_MAINMENU
@@ -4006,7 +4006,7 @@ void menuReset(void)
 
 	g_MenuData.unk668 = -1;
 	g_MenuData.unk00c = 0;
-	g_MenuData.unk008 = -1;
+	g_MenuData.prevmenuroot = -1;
 	g_MenuData.count = 0;
 	g_MenuData.root = 0;
 	g_MenuData.unk010 = 0;

--- a/src/game/menu.c
+++ b/src/game/menu.c
@@ -3609,7 +3609,7 @@ void func0f0f820c(struct menudialogdef *dialogdef, s32 root)
 	g_MpPlayerNum = prevplayernum;
 
 	g_MenuData.prevmenuroot = root;
-	g_MenuData.unk00c = dialogdef;
+	g_MenuData.prevmenudialog = dialogdef;
 }
 
 void menuSetBackground(s32 bg)
@@ -4005,7 +4005,7 @@ void menuReset(void)
 	}
 
 	g_MenuData.unk668 = -1;
-	g_MenuData.unk00c = 0;
+	g_MenuData.prevmenudialog = 0;
 	g_MenuData.prevmenuroot = -1;
 	g_MenuData.count = 0;
 	g_MenuData.root = 0;

--- a/src/game/menutick.c
+++ b/src/game/menutick.c
@@ -498,13 +498,13 @@ void menuTick(void)
 				&& g_MenuData.prevmenuroot == -1) {
 			if (g_Vars.mpsetupmenu == MPSETUPMENU_GENERAL) {
 				g_MenuData.prevmenuroot = MENUROOT_MAINMENU;
-				g_MenuData.unk00c = IS4MB() ? &g_CiMenuViaPauseMenuDialog : &g_CiMenuViaPcMenuDialog;
+				g_MenuData.prevmenudialog = IS4MB() ? &g_CiMenuViaPauseMenuDialog : &g_CiMenuViaPcMenuDialog;
 			} else if (IS4MB()) {
 				g_MenuData.prevmenuroot = MENUROOT_4MBMAINMENU;
-				g_MenuData.unk00c = &g_MainMenu4MbMenuDialog;
+				g_MenuData.prevmenudialog = &g_MainMenu4MbMenuDialog;
 			} else {
 				g_MenuData.prevmenuroot = MENUROOT_MPSETUP;
-				g_MenuData.unk00c = &g_CombatSimulatorMenuDialog;
+				g_MenuData.prevmenudialog = &g_CombatSimulatorMenuDialog;
 			}
 		}
 
@@ -570,7 +570,7 @@ void menuTick(void)
 				musicQueueStopAllEvent();
 			} else {
 				bool startmusic = false;
-				menuPushRootDialog(g_MenuData.unk00c, g_MenuData.prevmenuroot);
+				menuPushRootDialog(g_MenuData.prevmenudialog, g_MenuData.prevmenuroot);
 				sp344 = true;
 
 				if (g_MenuData.root == MENUROOT_MPSETUP || g_MenuData.root == MENUROOT_4MBMAINMENU) {
@@ -597,7 +597,7 @@ void menuTick(void)
 				}
 			}
 
-			g_MenuData.unk00c = NULL;
+			g_MenuData.prevmenudialog = NULL;
 			g_MenuData.prevmenuroot = -1;
 		} else {
 			switch (g_MenuData.root) {

--- a/src/game/menutick.c
+++ b/src/game/menutick.c
@@ -285,7 +285,7 @@ void menuTick(void)
 		var8006294c = 1;
 
 		if (g_MenuData.root == MENUROOT_MPSETUP || g_MenuData.root == MENUROOT_4MBMAINMENU) {
-			if (g_MenuData.unk008 == -1) {
+			if (g_MenuData.prevmenuroot == -1) {
 				g_MpSetup.chrslots &= 0xfff0;
 			}
 
@@ -295,7 +295,7 @@ void menuTick(void)
 				if (g_Menus[i].curdialog) {
 					g_Menus[i].playernum = g_MpNumJoined++;
 
-					if (g_MenuData.unk008 == -1) {
+					if (g_MenuData.prevmenuroot == -1) {
 						g_MpSetup.chrslots |= (1 << i);
 					}
 				}
@@ -493,23 +493,23 @@ void menuTick(void)
 		}
 	}
 
-	if ((g_MenuData.unk5d5_06 || g_MenuData.unk008 != -1) && sp344 == false) {
+	if ((g_MenuData.unk5d5_06 || g_MenuData.prevmenuroot != -1) && sp344 == false) {
 		if ((g_MenuData.root == MENUROOT_MPSETUP || g_MenuData.root == MENUROOT_4MBMAINMENU)
-				&& g_MenuData.unk008 == -1) {
+				&& g_MenuData.prevmenuroot == -1) {
 			if (g_Vars.mpsetupmenu == MPSETUPMENU_GENERAL) {
-				g_MenuData.unk008 = MENUROOT_MAINMENU;
+				g_MenuData.prevmenuroot = MENUROOT_MAINMENU;
 				g_MenuData.unk00c = IS4MB() ? &g_CiMenuViaPauseMenuDialog : &g_CiMenuViaPcMenuDialog;
 			} else if (IS4MB()) {
-				g_MenuData.unk008 = MENUROOT_4MBMAINMENU;
+				g_MenuData.prevmenuroot = MENUROOT_4MBMAINMENU;
 				g_MenuData.unk00c = &g_MainMenu4MbMenuDialog;
 			} else {
-				g_MenuData.unk008 = MENUROOT_MPSETUP;
+				g_MenuData.prevmenuroot = MENUROOT_MPSETUP;
 				g_MenuData.unk00c = &g_CombatSimulatorMenuDialog;
 			}
 		}
 
-		if (g_MenuData.unk008 != -1) {
-			if (g_MenuData.unk008 == -5) {
+		if (g_MenuData.prevmenuroot != -1) {
+			if (g_MenuData.prevmenuroot == -5) {
 				// Match is beginning
 				mpStartMatch();
 				menuStop();
@@ -518,7 +518,7 @@ void menuTick(void)
 					bossfileSave();
 					g_Vars.modifiedfiles &= ~MODFILE_MPSETUP;
 				}
-			} else if (g_MenuData.unk008 == -6) {
+			} else if (g_MenuData.prevmenuroot == -6) {
 				// Match is ending
 				s32 playernum = 0;
 
@@ -561,7 +561,7 @@ void menuTick(void)
 						playernum++;
 					}
 				}
-			} else if (g_MenuData.unk008 == -7) {
+			} else if (g_MenuData.prevmenuroot == -7) {
 				menuStop();
 				g_FileState = FILESTATE_CHANGINGAGENT;
 				gamefileLoadDefaults(&g_GameFile);
@@ -570,7 +570,7 @@ void menuTick(void)
 				musicQueueStopAllEvent();
 			} else {
 				bool startmusic = false;
-				menuPushRootDialog(g_MenuData.unk00c, g_MenuData.unk008);
+				menuPushRootDialog(g_MenuData.unk00c, g_MenuData.prevmenuroot);
 				sp344 = true;
 
 				if (g_MenuData.root == MENUROOT_MPSETUP || g_MenuData.root == MENUROOT_4MBMAINMENU) {
@@ -598,7 +598,7 @@ void menuTick(void)
 			}
 
 			g_MenuData.unk00c = NULL;
-			g_MenuData.unk008 = -1;
+			g_MenuData.prevmenuroot = -1;
 		} else {
 			switch (g_MenuData.root) {
 			case MENUROOT_ENDSCREEN:

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -4786,7 +4786,7 @@ struct menudata {
 	/*0x000*/ s32 count;
 	/*0x004*/ s32 root;
 	/*0x008*/ s32 prevmenuroot; // also a menuroot constant
-	/*0x00c*/ struct menudialogdef *unk00c;
+	/*0x00c*/ struct menudialogdef *prevmenudialog;
 	/*0x010*/ f32 unk010;
 	/*0x014*/ u8 bg;
 	/*0x015*/ u8 nextbg;

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -4785,7 +4785,7 @@ struct menudata_5d8 {
 struct menudata {
 	/*0x000*/ s32 count;
 	/*0x004*/ s32 root;
-	/*0x008*/ s32 unk008; // also a menuroot constant
+	/*0x008*/ s32 prevmenuroot; // also a menuroot constant
 	/*0x00c*/ struct menudialogdef *unk00c;
 	/*0x010*/ f32 unk010;
 	/*0x014*/ u8 bg;


### PR DESCRIPTION
This is a backport from Friends of Joanna where I added a new menuroot and menu tree and discovered how these properties work together.

|`struct menudata` previous name  |   new name   | Description|
|-|-|-|
| `unk008` | `prevmenuroot` | When positive, used as intended menuroot constant to use when "backing out" of a menu tree and a new one needs to be created.|  When negative, used for intermediate states w/ undiscovered constants. | 
| `unk00c` | `prevmenudialog` | When truthy, dialog definition to use when "backing out" of a menu tree and a new one needs to be created.| 