### PR TITLE
Camera Sensitivity no longer tied to FOV Slider

### DIFF
--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -328,112 +328,112 @@ void bmoveUpdateSpeedTheta(void)
 
 f32 bmoveGetSpeedVertaLimit(f32 value)
 {
-	if (value > 0) {
-		return (viGetFovY() * value * -0.7f) / 60.0f;
-	}
+    if (value > 0) {
+        return (value * -0.7f);
+    }
 
-	if (value < 0) {
-		return (viGetFovY() * -value * 0.7f) / 60.0f;
-	}
+    if (value < 0) {
+        return (-value * 0.7f);
+    }
 
-	return 0;
+    return 0;
 }
 
 void bmoveUpdateSpeedVerta(f32 value)
 {
-	f32 mult = viGetFovY() / 60.0f;
-	f32 limit = bmoveGetSpeedVertaLimit(value);
+    f32 mult = 1.0f;
+    f32 limit = bmoveGetSpeedVertaLimit(value);
 
-	if (value > 0) {
-		if (g_Vars.currentplayer->speedverta > 0) {
-			g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
-		} else {
-			g_Vars.currentplayer->speedverta -= 0.0125f * g_Vars.lvupdate60freal * mult;
-		}
+    if (value > 0) {
+        if (g_Vars.currentplayer->speedverta > 0) {
+            g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
+        } else {
+            g_Vars.currentplayer->speedverta -= 0.0125f * g_Vars.lvupdate60freal * mult;
+        }
 
-		if (g_Vars.currentplayer->speedverta < limit) {
-			g_Vars.currentplayer->speedverta = limit;
-		}
-	} else if (value < 0) {
-		if (g_Vars.currentplayer->speedverta < 0) {
-			g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
-		} else {
-			g_Vars.currentplayer->speedverta += 0.0125f * g_Vars.lvupdate60freal * mult;
-		}
+        if (g_Vars.currentplayer->speedverta < limit) {
+            g_Vars.currentplayer->speedverta = limit;
+        }
+    } else if (value < 0) {
+        if (g_Vars.currentplayer->speedverta < 0) {
+            g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
+        } else {
+            g_Vars.currentplayer->speedverta += 0.0125f * g_Vars.lvupdate60freal * mult;
+        }
 
-		if (g_Vars.currentplayer->speedverta > limit) {
-			g_Vars.currentplayer->speedverta = limit;
-		}
-	} else {
-		if (g_Vars.currentplayer->speedverta > limit) {
-			g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
+        if (g_Vars.currentplayer->speedverta > limit) {
+            g_Vars.currentplayer->speedverta = limit;
+        }
+    } else {
+        if (g_Vars.currentplayer->speedverta > limit) {
+            g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
 
-			if (g_Vars.currentplayer->speedverta < limit) {
-				g_Vars.currentplayer->speedverta = limit;
-			}
-		} else {
-			g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
+            if (g_Vars.currentplayer->speedverta < limit) {
+                g_Vars.currentplayer->speedverta = limit;
+            }
+        } else {
+            g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
 
-			if (g_Vars.currentplayer->speedverta > limit) {
-				g_Vars.currentplayer->speedverta = limit;
-			}
-		}
-	}
+            if (g_Vars.currentplayer->speedverta > limit) {
+                g_Vars.currentplayer->speedverta = limit;
+            }
+        }
+    }
 }
 
 f32 bmoveGetSpeedThetaControlLimit(f32 value)
 {
-	if (value > 0) {
-		return (viGetFovY() * value * -0.7f) / 60.0f;
-	}
+    if (value > 0) {
+        return (value * -0.7f);
+    }
 
-	if (value < 0) {
-		return (viGetFovY() * -value * 0.7f) / 60.0f;
-	}
+    if (value < 0) {
+        return (-value * 0.7f);
+    }
 
-	return 0;
+    return 0;
 }
 
 void bmoveUpdateSpeedThetaControl(f32 value)
 {
-	f32 mult = viGetFovY() / 60.0f;
-	f32 limit = bmoveGetSpeedThetaControlLimit(value);
+    f32 mult = 1.0f;
+    f32 limit = bmoveGetSpeedThetaControlLimit(value);
 
-	if (value > 0) {
-		if (g_Vars.currentplayer->speedthetacontrol > 0) {
-			g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
-		} else {
-			g_Vars.currentplayer->speedthetacontrol -= 0.0125f * g_Vars.lvupdate60freal * mult;
-		}
+    if (value > 0) {
+        if (g_Vars.currentplayer->speedthetacontrol > 0) {
+            g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
+        } else {
+            g_Vars.currentplayer->speedthetacontrol -= 0.0125f * g_Vars.lvupdate60freal * mult;
+        }
 
-		if (g_Vars.currentplayer->speedthetacontrol < limit) {
-			g_Vars.currentplayer->speedthetacontrol = limit;
-		}
-	} else if (value < 0) {
-		if (g_Vars.currentplayer->speedthetacontrol < 0.0f) {
-			g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
-		} else {
-			g_Vars.currentplayer->speedthetacontrol += 0.0125f * g_Vars.lvupdate60freal * mult;
-		}
+        if (g_Vars.currentplayer->speedthetacontrol < limit) {
+            g_Vars.currentplayer->speedthetacontrol = limit;
+        }
+    } else if (value < 0) {
+        if (g_Vars.currentplayer->speedthetacontrol < 0.0f) {
+            g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
+        } else {
+            g_Vars.currentplayer->speedthetacontrol += 0.0125f * g_Vars.lvupdate60freal * mult;
+        }
 
-		if (g_Vars.currentplayer->speedthetacontrol > limit) {
-			g_Vars.currentplayer->speedthetacontrol = limit;
-		}
-	} else {
-		if (g_Vars.currentplayer->speedthetacontrol > limit) {
-			g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
+        if (g_Vars.currentplayer->speedthetacontrol > limit) {
+            g_Vars.currentplayer->speedthetacontrol = limit;
+        }
+    } else {
+        if (g_Vars.currentplayer->speedthetacontrol > limit) {
+            g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
 
-			if (g_Vars.currentplayer->speedthetacontrol < limit) {
-				g_Vars.currentplayer->speedthetacontrol = limit;
-			}
-		} else {
-			g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
+            if (g_Vars.currentplayer->speedthetacontrol < limit) {
+                g_Vars.currentplayer->speedthetacontrol = limit;
+            }
+        } else {
+            g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
 
-			if (g_Vars.currentplayer->speedthetacontrol > limit) {
-				g_Vars.currentplayer->speedthetacontrol = limit;
-			}
-		}
-	}
+            if (g_Vars.currentplayer->speedthetacontrol > limit) {
+                g_Vars.currentplayer->speedthetacontrol = limit;
+            }
+        }
+    }
 }
 
 /**
@@ -2032,7 +2032,7 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 			}
 		} else {
 			if (movedata.cannaturalpitch) {
-				tmp = viGetFovY() / 60.0f;
+				tmp = 1.0f;
 				fVar25 = movedata.analogpitch / 70.0f;
 
 				if (fVar25 > 1) {
@@ -2073,7 +2073,7 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 	}
 
 	if (movedata.cannaturalturn) {
-		tmp = viGetFovY() / 60.0f;
+		tmp = 1.0f;
 		fVar25 = movedata.analogturn / 70.0f;
 
 		if (fVar25 > 1) {

--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -328,112 +328,113 @@ void bmoveUpdateSpeedTheta(void)
 
 f32 bmoveGetSpeedVertaLimit(f32 value)
 {
-		if (value > 0) {
-				return(value * -0.7f);
-		}
-		if (value < 0) {
-				return(-value * 0.7f);
-		}
-		return 0;
+	if (value > 0) {
+		return (viGetFovY() * value * -0.7f) / PLAYER_DEFAULT_FOV;
+	}
+
+	if (value < 0) {
+		return (viGetFovY() * -value * 0.7f) / PLAYER_DEFAULT_FOV;
+	}
+
+	return 0;
 }
 
 void bmoveUpdateSpeedVerta(f32 value)
 {
-		f32 mult = 1.0f;
-		f32 limit = bmoveGetSpeedVertaLimit(value);
+	f32 mult = viGetFovY() / PLAYER_DEFAULT_FOV;
+	f32 limit = bmoveGetSpeedVertaLimit(value);
 
-		if (value > 0) {
-				if (g_Vars.currentplayer->speedverta > 0) {
-						g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
-				}
-				else {
-						g_Vars.currentplayer->speedverta -= 0.0125f * g_Vars.lvupdate60freal * mult;
-				}
-				if (g_Vars.currentplayer->speedverta < limit) {
-						g_Vars.currentplayer->speedverta = limit;
-				}
+	if (value > 0) {
+		if (g_Vars.currentplayer->speedverta > 0) {
+			g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
+		} else {
+			g_Vars.currentplayer->speedverta -= 0.0125f * g_Vars.lvupdate60freal * mult;
 		}
-		else if (value < 0) {
-				if (g_Vars.currentplayer->speedverta < 0) {
-						g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
-				}
-				else {
-						g_Vars.currentplayer->speedverta += 0.0125f * g_Vars.lvupdate60freal * mult;
-				}
-				if (g_Vars.currentplayer->speedverta > limit) {
-						g_Vars.currentplayer->speedverta = limit;
-				}
+
+		if (g_Vars.currentplayer->speedverta < limit) {
+			g_Vars.currentplayer->speedverta = limit;
 		}
-		else {
-				if (g_Vars.currentplayer->speedverta > limit) {
-						g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
-						if (g_Vars.currentplayer->speedverta < limit) {
-								g_Vars.currentplayer->speedverta = limit;
-						}
-				}
-				else {
-						g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
-						if (g_Vars.currentplayer->speedverta > limit) {
-								g_Vars.currentplayer->speedverta = limit;
-						}
-				}
+	} else if (value < 0) {
+		if (g_Vars.currentplayer->speedverta < 0) {
+			g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
+		} else {
+			g_Vars.currentplayer->speedverta += 0.0125f * g_Vars.lvupdate60freal * mult;
 		}
+
+		if (g_Vars.currentplayer->speedverta > limit) {
+			g_Vars.currentplayer->speedverta = limit;
+		}
+	} else {
+		if (g_Vars.currentplayer->speedverta > limit) {
+			g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
+
+			if (g_Vars.currentplayer->speedverta < limit) {
+				g_Vars.currentplayer->speedverta = limit;
+			}
+		} else {
+			g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
+
+			if (g_Vars.currentplayer->speedverta > limit) {
+				g_Vars.currentplayer->speedverta = limit;
+			}
+		}
+	}
 }
 
 f32 bmoveGetSpeedThetaControlLimit(f32 value)
 {
-		if (value > 0) {
-				return(value * -0.7f);
-		}
-		if (value < 0) {
-				return(-value * 0.7f);
-		}
-		return 0;
+	if (value > 0) {
+		return (viGetFovY() * value * -0.7f) / PLAYER_DEFAULT_FOV;
+	}
+
+	if (value < 0) {
+		return (viGetFovY() * -value * 0.7f) / PLAYER_DEFAULT_FOV;
+	}
+
+	return 0;
 }
 
 void bmoveUpdateSpeedThetaControl(f32 value)
 {
-		f32 mult = 1.0f;
-		f32 limit = bmoveGetSpeedThetaControlLimit(value);
+	f32 mult = viGetFovY() / PLAYER_DEFAULT_FOV;
+	f32 limit = bmoveGetSpeedThetaControlLimit(value);
 
-		if (value > 0) {
-				if (g_Vars.currentplayer->speedthetacontrol > 0) {
-						g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
-				}
-				else {
-						g_Vars.currentplayer->speedthetacontrol -= 0.0125f * g_Vars.lvupdate60freal * mult;
-				}
-				if (g_Vars.currentplayer->speedthetacontrol < limit) {
-						g_Vars.currentplayer->speedthetacontrol = limit;
-				}
+	if (value > 0) {
+		if (g_Vars.currentplayer->speedthetacontrol > 0) {
+			g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
+		} else {
+			g_Vars.currentplayer->speedthetacontrol -= 0.0125f * g_Vars.lvupdate60freal * mult;
 		}
-		else if (value < 0) {
-				if (g_Vars.currentplayer->speedthetacontrol < 0.0f) {
-						g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
-				}
-				else {
-						g_Vars.currentplayer->speedthetacontrol += 0.0125f * g_Vars.lvupdate60freal * mult;
-				}
-				if (g_Vars.currentplayer->speedthetacontrol > limit) {
-						g_Vars.currentplayer->speedthetacontrol = limit;
-				}
+
+		if (g_Vars.currentplayer->speedthetacontrol < limit) {
+			g_Vars.currentplayer->speedthetacontrol = limit;
 		}
-		else {
-				if (g_Vars.currentplayer->speedthetacontrol > limit) {
-						g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
-						if (g_Vars.currentplayer->speedthetacontrol < limit) {
-								g_Vars.currentplayer->speedthetacontrol = limit;
-						}
-				}
-				else {
-						g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
-						if (g_Vars.currentplayer->speedthetacontrol > limit) {
-								g_Vars.currentplayer->speedthetacontrol = limit;
-						}
-				}
+	} else if (value < 0) {
+		if (g_Vars.currentplayer->speedthetacontrol < 0.0f) {
+			g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
+		} else {
+			g_Vars.currentplayer->speedthetacontrol += 0.0125f * g_Vars.lvupdate60freal * mult;
 		}
+
+		if (g_Vars.currentplayer->speedthetacontrol > limit) {
+			g_Vars.currentplayer->speedthetacontrol = limit;
+		}
+	} else {
+		if (g_Vars.currentplayer->speedthetacontrol > limit) {
+			g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
+
+			if (g_Vars.currentplayer->speedthetacontrol < limit) {
+				g_Vars.currentplayer->speedthetacontrol = limit;
+			}
+		} else {
+			g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
+
+			if (g_Vars.currentplayer->speedthetacontrol > limit) {
+				g_Vars.currentplayer->speedthetacontrol = limit;
+			}
+		}
+	}
 }
-
 
 /**
  * Calculate the lookahead angle.
@@ -2031,7 +2032,7 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 			}
 		} else {
 			if (movedata.cannaturalpitch) {
-				tmp = 1.0f;
+				tmp = viGetFovY() / PLAYER_DEFAULT_FOV;
 				fVar25 = movedata.analogpitch / 70.0f;
 
 				if (fVar25 > 1) {
@@ -2072,7 +2073,7 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 	}
 
 	if (movedata.cannaturalturn) {
-		tmp = 1.0f;
+		tmp = viGetFovY() / PLAYER_DEFAULT_FOV;
 		fVar25 = movedata.analogturn / 70.0f;
 
 		if (fVar25 > 1) {

--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -326,115 +326,100 @@ void bmoveUpdateSpeedTheta(void)
 	}
 }
 
-f32 bmoveGetSpeedVertaLimit(f32 value)
-{
-    if (value > 0) {
-        return (value * -0.7f);
+f32 bmoveGetSpeedVertaLimit(f32 value){
+    if(value > 0){
+        return(value * -0.7f);
     }
-
-    if (value < 0) {
-        return (-value * 0.7f);
+    if(value < 0){
+        return(-value * 0.7f);
     }
-
     return 0;
 }
 
-void bmoveUpdateSpeedVerta(f32 value)
-{
+void bmoveUpdateSpeedVerta(f32 value){
     f32 mult = 1.0f;
     f32 limit = bmoveGetSpeedVertaLimit(value);
-
-    if (value > 0) {
-        if (g_Vars.currentplayer->speedverta > 0) {
+    
+    if(value > 0){
+        if(g_Vars.currentplayer->speedverta > 0){
             g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
-        } else {
+        }else{
             g_Vars.currentplayer->speedverta -= 0.0125f * g_Vars.lvupdate60freal * mult;
         }
-
-        if (g_Vars.currentplayer->speedverta < limit) {
+        if(g_Vars.currentplayer->speedverta < limit){
             g_Vars.currentplayer->speedverta = limit;
         }
-    } else if (value < 0) {
-        if (g_Vars.currentplayer->speedverta < 0) {
+    }else if(value < 0){
+        if(g_Vars.currentplayer->speedverta < 0){
             g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
-        } else {
+        }else{
             g_Vars.currentplayer->speedverta += 0.0125f * g_Vars.lvupdate60freal * mult;
         }
-
-        if (g_Vars.currentplayer->speedverta > limit) {
+        if(g_Vars.currentplayer->speedverta > limit){
             g_Vars.currentplayer->speedverta = limit;
         }
-    } else {
-        if (g_Vars.currentplayer->speedverta > limit) {
+    }else{
+        if(g_Vars.currentplayer->speedverta > limit){
             g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
-
-            if (g_Vars.currentplayer->speedverta < limit) {
+            if(g_Vars.currentplayer->speedverta < limit){
                 g_Vars.currentplayer->speedverta = limit;
             }
-        } else {
+        }else{
             g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
-
-            if (g_Vars.currentplayer->speedverta > limit) {
+            if(g_Vars.currentplayer->speedverta > limit){
                 g_Vars.currentplayer->speedverta = limit;
             }
         }
     }
 }
 
-f32 bmoveGetSpeedThetaControlLimit(f32 value)
-{
-    if (value > 0) {
-        return (value * -0.7f);
+f32 bmoveGetSpeedThetaControlLimit(f32 value){
+    if(value > 0){
+        return(value * -0.7f);
     }
-
-    if (value < 0) {
-        return (-value * 0.7f);
+    if(value < 0){
+        return(-value * 0.7f);
     }
-
     return 0;
 }
 
-void bmoveUpdateSpeedThetaControl(f32 value)
-{
+void bmoveUpdateSpeedThetaControl(f32 value){
     f32 mult = 1.0f;
     f32 limit = bmoveGetSpeedThetaControlLimit(value);
-
-    if (value > 0) {
-        if (g_Vars.currentplayer->speedthetacontrol > 0) {
+    
+    if(value > 0){
+        if(g_Vars.currentplayer->speedthetacontrol > 0){
             g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
-        } else {
+        }else{
             g_Vars.currentplayer->speedthetacontrol -= 0.0125f * g_Vars.lvupdate60freal * mult;
         }
-
-        if (g_Vars.currentplayer->speedthetacontrol < limit) {
+        if(g_Vars.currentplayer->speedthetacontrol < limit){
             g_Vars.currentplayer->speedthetacontrol = limit;
         }
-    } else if (value < 0) {
-        if (g_Vars.currentplayer->speedthetacontrol < 0.0f) {
+    }else if(value < 0){
+        if(g_Vars.currentplayer->speedthetacontrol < 0.0f){
             g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
-        } else {
+        }else{
             g_Vars.currentplayer->speedthetacontrol += 0.0125f * g_Vars.lvupdate60freal * mult;
         }
-
-        if (g_Vars.currentplayer->speedthetacontrol > limit) {
+        if(g_Vars.currentplayer->speedthetacontrol > limit){
             g_Vars.currentplayer->speedthetacontrol = limit;
         }
-    } else {
-        if (g_Vars.currentplayer->speedthetacontrol > limit) {
+    }else{
+        if(g_Vars.currentplayer->speedthetacontrol > limit){
             g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
-
-            if (g_Vars.currentplayer->speedthetacontrol < limit) {
+            if(g_Vars.currentplayer->speedthetacontrol < limit){
                 g_Vars.currentplayer->speedthetacontrol = limit;
             }
-        } else {
+        }else{
             g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
-
-            if (g_Vars.currentplayer->speedthetacontrol > limit) {
+            if(g_Vars.currentplayer->speedthetacontrol > limit){
                 g_Vars.currentplayer->speedthetacontrol = limit;
             }
         }
     }
 }
+
 
 /**
  * Calculate the lookahead angle.

--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -2031,7 +2031,7 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 			}
 		} else {
 			if (movedata.cannaturalpitch) {
-					tmp = 1.0f;
+				tmp = 1.0f;
 				fVar25 = movedata.analogpitch / 70.0f;
 
 				if (fVar25 > 1) {

--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -326,98 +326,112 @@ void bmoveUpdateSpeedTheta(void)
 	}
 }
 
-f32 bmoveGetSpeedVertaLimit(f32 value){
-    if(value > 0){
-        return(value * -0.7f);
-    }
-    if(value < 0){
-        return(-value * 0.7f);
-    }
-    return 0;
+f32 bmoveGetSpeedVertaLimit(f32 value)
+{
+		if (value > 0) {
+				return(value * -0.7f);
+		}
+		if (value < 0) {
+				return(-value * 0.7f);
+		}
+		return 0;
 }
 
-void bmoveUpdateSpeedVerta(f32 value){
-    f32 mult = 1.0f;
-    f32 limit = bmoveGetSpeedVertaLimit(value);
-    
-    if(value > 0){
-        if(g_Vars.currentplayer->speedverta > 0){
-            g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
-        }else{
-            g_Vars.currentplayer->speedverta -= 0.0125f * g_Vars.lvupdate60freal * mult;
-        }
-        if(g_Vars.currentplayer->speedverta < limit){
-            g_Vars.currentplayer->speedverta = limit;
-        }
-    }else if(value < 0){
-        if(g_Vars.currentplayer->speedverta < 0){
-            g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
-        }else{
-            g_Vars.currentplayer->speedverta += 0.0125f * g_Vars.lvupdate60freal * mult;
-        }
-        if(g_Vars.currentplayer->speedverta > limit){
-            g_Vars.currentplayer->speedverta = limit;
-        }
-    }else{
-        if(g_Vars.currentplayer->speedverta > limit){
-            g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
-            if(g_Vars.currentplayer->speedverta < limit){
-                g_Vars.currentplayer->speedverta = limit;
-            }
-        }else{
-            g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
-            if(g_Vars.currentplayer->speedverta > limit){
-                g_Vars.currentplayer->speedverta = limit;
-            }
-        }
-    }
+void bmoveUpdateSpeedVerta(f32 value)
+{
+		f32 mult = 1.0f;
+		f32 limit = bmoveGetSpeedVertaLimit(value);
+
+		if (value > 0) {
+				if (g_Vars.currentplayer->speedverta > 0) {
+						g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
+				}
+				else {
+						g_Vars.currentplayer->speedverta -= 0.0125f * g_Vars.lvupdate60freal * mult;
+				}
+				if (g_Vars.currentplayer->speedverta < limit) {
+						g_Vars.currentplayer->speedverta = limit;
+				}
+		}
+		else if (value < 0) {
+				if (g_Vars.currentplayer->speedverta < 0) {
+						g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
+				}
+				else {
+						g_Vars.currentplayer->speedverta += 0.0125f * g_Vars.lvupdate60freal * mult;
+				}
+				if (g_Vars.currentplayer->speedverta > limit) {
+						g_Vars.currentplayer->speedverta = limit;
+				}
+		}
+		else {
+				if (g_Vars.currentplayer->speedverta > limit) {
+						g_Vars.currentplayer->speedverta -= 0.05f * g_Vars.lvupdate60freal * mult;
+						if (g_Vars.currentplayer->speedverta < limit) {
+								g_Vars.currentplayer->speedverta = limit;
+						}
+				}
+				else {
+						g_Vars.currentplayer->speedverta += 0.05f * g_Vars.lvupdate60freal * mult;
+						if (g_Vars.currentplayer->speedverta > limit) {
+								g_Vars.currentplayer->speedverta = limit;
+						}
+				}
+		}
 }
 
-f32 bmoveGetSpeedThetaControlLimit(f32 value){
-    if(value > 0){
-        return(value * -0.7f);
-    }
-    if(value < 0){
-        return(-value * 0.7f);
-    }
-    return 0;
+f32 bmoveGetSpeedThetaControlLimit(f32 value)
+{
+		if (value > 0) {
+				return(value * -0.7f);
+		}
+		if (value < 0) {
+				return(-value * 0.7f);
+		}
+		return 0;
 }
 
-void bmoveUpdateSpeedThetaControl(f32 value){
-    f32 mult = 1.0f;
-    f32 limit = bmoveGetSpeedThetaControlLimit(value);
-    
-    if(value > 0){
-        if(g_Vars.currentplayer->speedthetacontrol > 0){
-            g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
-        }else{
-            g_Vars.currentplayer->speedthetacontrol -= 0.0125f * g_Vars.lvupdate60freal * mult;
-        }
-        if(g_Vars.currentplayer->speedthetacontrol < limit){
-            g_Vars.currentplayer->speedthetacontrol = limit;
-        }
-    }else if(value < 0){
-        if(g_Vars.currentplayer->speedthetacontrol < 0.0f){
-            g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
-        }else{
-            g_Vars.currentplayer->speedthetacontrol += 0.0125f * g_Vars.lvupdate60freal * mult;
-        }
-        if(g_Vars.currentplayer->speedthetacontrol > limit){
-            g_Vars.currentplayer->speedthetacontrol = limit;
-        }
-    }else{
-        if(g_Vars.currentplayer->speedthetacontrol > limit){
-            g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
-            if(g_Vars.currentplayer->speedthetacontrol < limit){
-                g_Vars.currentplayer->speedthetacontrol = limit;
-            }
-        }else{
-            g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
-            if(g_Vars.currentplayer->speedthetacontrol > limit){
-                g_Vars.currentplayer->speedthetacontrol = limit;
-            }
-        }
-    }
+void bmoveUpdateSpeedThetaControl(f32 value)
+{
+		f32 mult = 1.0f;
+		f32 limit = bmoveGetSpeedThetaControlLimit(value);
+
+		if (value > 0) {
+				if (g_Vars.currentplayer->speedthetacontrol > 0) {
+						g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
+				}
+				else {
+						g_Vars.currentplayer->speedthetacontrol -= 0.0125f * g_Vars.lvupdate60freal * mult;
+				}
+				if (g_Vars.currentplayer->speedthetacontrol < limit) {
+						g_Vars.currentplayer->speedthetacontrol = limit;
+				}
+		}
+		else if (value < 0) {
+				if (g_Vars.currentplayer->speedthetacontrol < 0.0f) {
+						g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
+				}
+				else {
+						g_Vars.currentplayer->speedthetacontrol += 0.0125f * g_Vars.lvupdate60freal * mult;
+				}
+				if (g_Vars.currentplayer->speedthetacontrol > limit) {
+						g_Vars.currentplayer->speedthetacontrol = limit;
+				}
+		}
+		else {
+				if (g_Vars.currentplayer->speedthetacontrol > limit) {
+						g_Vars.currentplayer->speedthetacontrol -= 0.05f * g_Vars.lvupdate60freal * mult;
+						if (g_Vars.currentplayer->speedthetacontrol < limit) {
+								g_Vars.currentplayer->speedthetacontrol = limit;
+						}
+				}
+				else {
+						g_Vars.currentplayer->speedthetacontrol += 0.05f * g_Vars.lvupdate60freal * mult;
+						if (g_Vars.currentplayer->speedthetacontrol > limit) {
+								g_Vars.currentplayer->speedthetacontrol = limit;
+						}
+				}
+		}
 }
 
 
@@ -2017,7 +2031,7 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 			}
 		} else {
 			if (movedata.cannaturalpitch) {
-				tmp = 1.0f;
+					tmp = 1.0f;
 				fVar25 = movedata.analogpitch / 70.0f;
 
 				if (fVar25 > 1) {


### PR DESCRIPTION
As reported on https://github.com/fgsfdsfgs/perfect_dark/issues/606, the FOV Slider will affect the Mouse (and perhaps Gyro?) Camera sensitivity scale.  

but now, it's been fixed by...~~removing `viGetFov` entirely~~ using `PLAYER_DEFAULT_FOV`

As of this writing, this has been briefly tested on the hub area using a 360-degree camera turn macro and using Sniper Rifle's Zoom functionality, but there's a chance that it could cause unforeseen issues, including splitscreen functionality.

