### PR TITLE
refactor(menu): rename unk5d5_06 and sp344 for clarity

### DIFF
--- a/src/game/menu.c
+++ b/src/game/menu.c
@@ -4011,7 +4011,7 @@ void menuReset(void)
 	g_MenuData.root = 0;
 	g_MenuData.unk010 = 0;
 	g_MenuData.bg = 0;
-	g_MenuData.unk5d5_06 = false;
+	g_MenuData.isdialogopen = false;
 	g_MenuData.nextbg = 255;
 	g_MenuData.bannernum = -1;
 

--- a/src/game/menutick.c
+++ b/src/game/menutick.c
@@ -59,7 +59,7 @@ void menuTick(void)
 	s32 i;
 	s32 j;
 	s32 k;
-	s32 sp344;
+	s32 isdialogopen;
 	s32 sp340 = true;
 	s32 anyopen = false;
 
@@ -485,15 +485,15 @@ void menuTick(void)
 	}
 
 	g_MpPlayerNum = 0;
-	sp344 = false;
+	isdialogopen = false;
 
 	for (i = 0; i < ARRAYCOUNT(g_Menus); i++) {
 		if (g_Menus[i].curdialog) {
-			sp344 = true;
+			isdialogopen = true;
 		}
 	}
 
-	if ((g_MenuData.unk5d5_06 || g_MenuData.prevmenuroot != -1) && sp344 == false) {
+	if ((g_MenuData.isdialogopen || g_MenuData.prevmenuroot != -1) && isdialogopen == false) {
 		if ((g_MenuData.root == MENUROOT_MPSETUP || g_MenuData.root == MENUROOT_4MBMAINMENU)
 				&& g_MenuData.prevmenuroot == -1) {
 			if (g_Vars.mpsetupmenu == MPSETUPMENU_GENERAL) {
@@ -541,17 +541,17 @@ void menuTick(void)
 								setCurrentPlayerNum(playernum);
 								endscreenPushCoop();
 								setCurrentPlayerNum(prevplayernum);
-								sp344 = true;
+								isdialogopen = true;
 							}
 						} else if (g_Vars.antiplayernum >= 0) {
 							s32 prevplayernum = g_Vars.currentplayernum;
 							setCurrentPlayerNum(playernum);
 							endscreenPushAnti();
 							setCurrentPlayerNum(prevplayernum);
-							sp344 = true;
+							isdialogopen = true;
 						} else {
 							mpPushEndscreenDialog(playernum, i);
-							sp344 = true;
+							isdialogopen = true;
 
 							if (g_PlayerConfigsArray[i].fileguid.fileid && g_PlayerConfigsArray[i].fileguid.deviceserial) {
 								func0f0fd548(i);
@@ -571,7 +571,7 @@ void menuTick(void)
 			} else {
 				bool startmusic = false;
 				menuPushRootDialog(g_MenuData.prevmenudialog, g_MenuData.prevmenuroot);
-				sp344 = true;
+				isdialogopen = true;
 
 				if (g_MenuData.root == MENUROOT_MPSETUP || g_MenuData.root == MENUROOT_4MBMAINMENU) {
 					startmusic = true;
@@ -750,5 +750,5 @@ void menuTick(void)
 	}
 
 	g_ScaleX = 1;
-	g_MenuData.unk5d5_06 = sp344 ? true : false;
+	g_MenuData.isdialogopen = isdialogopen ? true : false;
 }

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -4802,7 +4802,7 @@ struct menudata {
 	/*0x5d5*/ u8 usezbuf : 1;
 	/*0x5d5*/ u8 unk5d5_04 : 1;
 	/*0x5d5*/ u8 unk5d5_05 : 1;
-	/*0x5d5*/ u8 unk5d5_06 : 1;
+	/*0x5d5*/ u8 isdialogopen : 1;
 	/*0x5d5*/ u8 unk5d5_07 : 1;
 	/*0x5d5*/ u8 unk5d5_08 : 1;
 	/*0x5d8*/ struct menudata_5d8 unk5d8[12];


### PR DESCRIPTION
Backport from Friends of Joanna: renamed the bool member `unk5d5_06` in the `menudata` struct to `isdialogopen` to clarify its purpose as a dialog state flag. Also renamed the local bool variable `sp344` in `menutick.c` to `isdialogopen` to reflect its relation to the struct member. Updated all references for consistency and improved readability.