### PR TITLE
port-mp-setups: a bunch of bug fixes

### DIFF
--- a/port/src/mpsetups.c
+++ b/port/src/mpsetups.c
@@ -809,7 +809,7 @@ static MenuItemHandlerResult menuhandlerSetupSetDefault(s32 operation, struct me
 		s32 selected = g_Menus[g_MpPlayerNum].mpsetup.slotindex;
 		// clicked on "clear default"
 		if (selected == g_MpSetupFile.defaultsetup - 1) {
-			g_MpSetupFile.defaultsetup = -1;
+			g_MpSetupFile.defaultsetup = 0;
 			strcpy(g_LabelSetDefault, "Set Default\n");
 		} else {
 			g_MpSetupFile.defaultsetup = selected + 1;

--- a/src/game/filemgr.c
+++ b/src/game/filemgr.c
@@ -2734,7 +2734,7 @@ MenuItemHandlerResult filemgrChooseAgentListMenuHandler(s32 operation, struct me
 				g_GameFileGuid.deviceserial = file->deviceserial;
 				filemgrSaveOrLoad(&g_GameFileGuid, FILEOP_LOAD_GAME, 0);
 
-                // load the setup file when loading the agent
+				// load the setup file when loading the agent
 				mpsetupCopyAllFromPak();
 				mpsetupLoadCurrentFile();
 			}

--- a/src/game/filemgr.c
+++ b/src/game/filemgr.c
@@ -19,6 +19,7 @@
 #include "lib/str.h"
 #include "data.h"
 #include "types.h"
+#include "mpsetups.h"
 
 // bss
 struct fileguid g_FilemgrFileToCopy;
@@ -2732,6 +2733,10 @@ MenuItemHandlerResult filemgrChooseAgentListMenuHandler(s32 operation, struct me
 				g_GameFileGuid.fileid = file->fileid;
 				g_GameFileGuid.deviceserial = file->deviceserial;
 				filemgrSaveOrLoad(&g_GameFileGuid, FILEOP_LOAD_GAME, 0);
+
+                // load the setup file when entering the Combat Simulator
+                mpsetupCopyAllFromPak();
+                mpsetupLoadCurrentFile();
 			}
 		}
 		break;

--- a/src/game/filemgr.c
+++ b/src/game/filemgr.c
@@ -19,6 +19,7 @@
 #include "lib/str.h"
 #include "data.h"
 #include "types.h"
+#include "mpsetups.h"
 
 // bss
 struct fileguid g_FilemgrFileToCopy;
@@ -2732,6 +2733,10 @@ MenuItemHandlerResult filemgrChooseAgentListMenuHandler(s32 operation, struct me
 				g_GameFileGuid.fileid = file->fileid;
 				g_GameFileGuid.deviceserial = file->deviceserial;
 				filemgrSaveOrLoad(&g_GameFileGuid, FILEOP_LOAD_GAME, 0);
+
+                // load the setup file when loading the agent
+                mpsetupCopyAllFromPak();
+                mpsetupLoadCurrentFile();
 			}
 		}
 		break;

--- a/src/game/filemgr.c
+++ b/src/game/filemgr.c
@@ -2735,8 +2735,8 @@ MenuItemHandlerResult filemgrChooseAgentListMenuHandler(s32 operation, struct me
 				filemgrSaveOrLoad(&g_GameFileGuid, FILEOP_LOAD_GAME, 0);
 
                 // load the setup file when loading the agent
-                mpsetupCopyAllFromPak();
-                mpsetupLoadCurrentFile();
+				mpsetupCopyAllFromPak();
+				mpsetupLoadCurrentFile();
 			}
 		}
 		break;

--- a/src/game/mplayer/setup.c
+++ b/src/game/mplayer/setup.c
@@ -5394,10 +5394,6 @@ MenuDialogHandlerResult menudialogCombatSimulator(s32 operation, struct menudial
 		g_Vars.waitingtojoin[1] = false;
 		g_Vars.waitingtojoin[2] = false;
 		g_Vars.waitingtojoin[3] = false;
-
-		// load the setup file when entering the Combat Simulator
-		mpsetupCopyAllFromPak();
-		mpsetupLoadCurrentFile();
 	}
 
 	if (g_Menus[g_MpPlayerNum].curdialog

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -3779,7 +3779,7 @@ struct menudata_mpsetup {
 	u32 unke24;
 	u32 unke28;
 	u32 unke2c;
-    u8 showpresets;
+	u8 showpresets;
 };
 
 struct menudata_mppause {
@@ -3992,7 +3992,7 @@ struct menu {
 		struct menudata_filemgr fm;
 		struct menudata_main4mb main4mb;
 		struct menudata_training training;
-        struct menudata_mpsetup mpsetup;
+		struct menudata_mpsetup mpsetup;
 	};
 
 };

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -3776,8 +3776,10 @@ struct menudata_main {
 struct menudata_mpsetup {
 	u32 slotindex;
 	u32 slotcount;
-	u8 showpresets;
 	u32 unke24;
+	u32 unke28;
+	u32 unke2c;
+    u8 showpresets;
 };
 
 struct menudata_mppause {
@@ -3990,9 +3992,9 @@ struct menu {
 		struct menudata_filemgr fm;
 		struct menudata_main4mb main4mb;
 		struct menudata_training training;
+        struct menudata_mpsetup mpsetup;
 	};
 
-	struct menudata_mpsetup mpsetup;
 };
 
 struct gamefile {


### PR DESCRIPTION
- only load the MP setup file when loading the agent, instead of when entering CS
- "clear default" would cause the game setup to become invalid upon re-entering it
- all challenges were showing the same text