### PR TITLE
Crosshair Edge Deadzone slider and fixed `insightaim` Camera Movement

### DIFF
--- a/port/src/main.c
+++ b/port/src/main.c
@@ -179,6 +179,7 @@ PD_CONSTRUCTOR static void gameConfigInit(void)
 		configRegisterFloat(strFmt("Game.Player%d.MouseAimSpeedY", i), &g_PlayerExtCfg[j].mouseaimspeedy, 0.f, 10.f);
 		configRegisterFloat(strFmt("Game.Player%d.RadialMenuSpeed", i), &g_PlayerExtCfg[j].radialmenuspeed, 0.f, 10.f);
 		configRegisterFloat(strFmt("Game.Player%d.CrosshairSway", i), &g_PlayerExtCfg[j].crosshairsway, 0.f, 10.f);
+		configRegisterFloat(strFmt("Game.Player%d.CrosshairEdgeBoundary", i), &g_PlayerExtCfg[j].crosshairedgeboundary, 0.0f, 1.0f);
 		configRegisterInt(strFmt("Game.Player%d.CrouchMode", i), &g_PlayerExtCfg[j].crouchmode, 0, CROUCHMODE_TOGGLE_ANALOG);
 		configRegisterInt(strFmt("Game.Player%d.ExtendedControls", i), &g_PlayerExtCfg[j].extcontrols, 0, 1);
 		configRegisterUInt(strFmt("Game.Player%d.CrosshairColour", i), &g_PlayerExtCfg[j].crosshaircolour, 0, 0xFFFFFFFF);

--- a/port/src/optionsmenu.c
+++ b/port/src/optionsmenu.c
@@ -1291,6 +1291,22 @@ static MenuItemHandlerResult menuhandlerCrosshairSway(s32 operation, struct menu
 	return 0;
 }
 
+static MenuItemHandlerResult menuhandlerCrosshairEdgeBoundary(s32 operation, struct menuitem* item, union handlerdata *data)
+{
+	switch (operation) {
+	case MENUOP_GETSLIDER:
+		data->slider.value = (s32)(g_PlayerExtCfg[g_ExtMenuPlayer].crosshairedgeboundary * 10.f + 0.5f);
+		break;
+	case MENUOP_SET:
+		g_PlayerExtCfg[g_ExtMenuPlayer].crosshairedgeboundary = (f32)data->slider.value / 10.f;
+		break;
+	case MENUOP_GETSLIDERLABEL:
+		sprintf(data->slider.label, "%d", (s32)data->slider.value);
+		break;
+	}
+	return 0;
+}
+
 static MenuItemHandlerResult menuhandlerCrosshairR(s32 operation, struct menuitem* item, union handlerdata* data)
 {
 	u32 newColor;
@@ -1511,6 +1527,14 @@ struct menuitem g_ExtendedGameMenuItems[] = {
 		(uintptr_t)"Crosshair Sway",
 		20,
 		menuhandlerCrosshairSway,
+	},
+	{
+		MENUITEMTYPE_SLIDER,
+		0,
+		MENUITEMFLAG_LITERAL_TEXT | MENUITEMFLAG_SLIDER_WIDE,
+		(uintptr_t)"Crosshair Edge Deadzone",
+		10,
+		menuhandlerCrosshairEdgeBoundary,
 	},
 	{
 		MENUITEMTYPE_SLIDER,

--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -1412,31 +1412,31 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 					}
 
 #ifndef PLATFORM_N64
-					// Handle turning and looking up/down via mouselook when aiming
-					if (g_Vars.currentplayer->insightaimmode && allowmcross && bgunGetWeaponNum(HAND_RIGHT) != WEAPON_HORIZONSCANNER) {
-						if (g_Vars.currentplayer->swivelpos[0] > 0.9f) {
-							movedata.aimturnrightspeed = (g_Vars.currentplayer->swivelpos[0] - 0.9f) / 0.1f;
-							movedata.aimturnleftspeed = 0.f;
-						} else if (g_Vars.currentplayer->swivelpos[0] < -0.9f) {
-							movedata.aimturnleftspeed = (g_Vars.currentplayer->swivelpos[0] - -0.9f) / -0.1f;
-							movedata.aimturnrightspeed = 0.f;
+					// Handle turning and looking (x/y) via mouselook when aiming
+					bool allowcross = allowmcross;
+					if (g_Vars.currentplayer->insightaimmode && allowcross && bgunGetWeaponNum(HAND_RIGHT) != WEAPON_HORIZONSCANNER) {
+						float edge_boundary = PLAYER_EXTCFG().crosshairedgeboundary;
+						if (g_Vars.currentplayer->swivelpos[0] > edge_boundary) {
+							movedata.aimturnrightspeed += (g_Vars.currentplayer->swivelpos[0] - edge_boundary) / (1.0f - edge_boundary);
+						} else if (g_Vars.currentplayer->swivelpos[0] < -edge_boundary) {
+							movedata.aimturnleftspeed += (g_Vars.currentplayer->swivelpos[0] + edge_boundary) / -(1.0f - edge_boundary);
 						}
 						f32 vertaup = 0.f, vertadown = 0.f;
-						if (g_Vars.currentplayer->swivelpos[1] > 0.9f) {
-							vertaup = (g_Vars.currentplayer->swivelpos[1] - 0.9f) / 0.1f;
-						} else if (g_Vars.currentplayer->swivelpos[1] < -0.9f) {
-							vertadown = (g_Vars.currentplayer->swivelpos[1] - -0.9f) / -0.1f;
+						if (g_Vars.currentplayer->swivelpos[1] > edge_boundary) {
+							vertaup = (g_Vars.currentplayer->swivelpos[1] - edge_boundary) / (1.0f - edge_boundary);
+						} else if (g_Vars.currentplayer->swivelpos[1] < -edge_boundary) {
+							vertadown = (g_Vars.currentplayer->swivelpos[1] + edge_boundary) / -(1.0f - edge_boundary);
 						}
 						// Uninvert pitch if needed
 						if (movedata.invertpitch) {
-							movedata.speedvertaup = vertadown;
-							movedata.speedvertadown = vertaup;
+							movedata.speedvertaup += vertadown;
+							movedata.speedvertadown += vertaup;
 						} else {
-							movedata.speedvertaup = vertaup;
-							movedata.speedvertadown = vertadown;
+							movedata.speedvertaup += vertaup;
+							movedata.speedvertadown += vertadown;
 						}
 					} else {
-						// Reset mouse aim position when not mouse aiming
+						// Reset mouse/gyro aim position when not aiming
 						g_Vars.currentplayer->swivelpos[0] = 0.f;
 						g_Vars.currentplayer->swivelpos[1] = 0.f;
 					}

--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -1436,7 +1436,7 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 							movedata.speedvertadown += vertadown;
 						}
 					} else {
-						// Reset mouse/gyro aim position when not aiming
+						// Reset mouse aim position when not aiming
 						g_Vars.currentplayer->swivelpos[0] = 0.f;
 						g_Vars.currentplayer->swivelpos[1] = 0.f;
 					}

--- a/src/game/mplayer/mplayer.c
+++ b/src/game/mplayer/mplayer.c
@@ -139,6 +139,7 @@ struct mpweapon g_MpWeapons[NUM_MPWEAPONS] = {
 	.extcontrols = true, \
 	.crosshaircolour = 0x00ff0028, \
 	.crosshairsize = 2, \
+	.crosshairedgeboundary = 0.7f, \
 	.crosshairhealth = CROSSHAIR_HEALTH_OFF, \
 	.usereloads = false, \
 }

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -6158,6 +6158,7 @@ struct extplayerconfig {
 	s32 extcontrols;
 	u32 crosshaircolour;
 	u32 crosshairsize;
+	f32 crosshairedgeboundary;
 	s32 crosshairhealth;
 	s32 usereloads;
 };


### PR DESCRIPTION
You know how Wii games will include a "deadzone box" (or bounding box) to compensate for Wiimote's lack of right stick? well, i decided to include a similar functionality. As i'm wrapping up work on https://github.com/fgsfdsfgs/perfect_dark/pull/591, i thought to myself: "we should give one more setting", original plan was to do two separate funcitons, but ultimately went with a single setup to make it easier for Mouse users...and soon: Gyro.

so, i created a dedicated slider for it.

https://github.com/user-attachments/assets/6b9961f6-49aa-491a-87b1-05a1ab75c6c4

note: this only applies to Mouse and Gyro Movement, Joystick Movement will remained the same.

This PR also fixes Up/Down Movement while using Mouse Input with Joystick Camera, making it easier for SteamInput Gyro setups.