### PR TITLE
port: fix multi-monitor issues on Wayland

### DIFF
--- a/port/fast3d/gfx_sdl2.cpp
+++ b/port/fast3d/gfx_sdl2.cpp
@@ -108,8 +108,8 @@ static void gfx_sdl_init(const struct GfxWindowInitSettings *set) {
     int posY = set->y;
     int display_in_use = SDL_GetWindowDisplayIndex(wnd);
     if (display_in_use < 0) { // Fallback to default if out of bounds
-        posX = 100;
-        posY = 100;
+        posX = SDL_WINDOWPOS_UNDEFINED;
+        posY = SDL_WINDOWPOS_UNDEFINED;
     }
 
     if (set->centered) {


### PR DESCRIPTION
Wayland doesn't allow manipulations with window position. Unlike Windows primary monitor isn't placed on 0,0 so placing window at 100,100 won't give you primary display but leftmost one on most compositors. I haven't tested these changes on other platforms, but they should be compatible and don't cause any regressions.