### PR TITLE
Add "Extended" cheat menu and new "All Doors Unlocked" cheat 

### DIFF
--- a/port/src/optionsmenu.c
+++ b/port/src/optionsmenu.c
@@ -6,6 +6,7 @@
 #include "platform.h"
 #include "data.h"
 #include "types.h"
+#include "game/cheats.h"
 #include "game/mainmenu.h"
 #include "game/menu.h"
 #include "game/gamefile.h"
@@ -1919,6 +1920,14 @@ struct menuitem g_ExtendedMenuItems[] = {
 		(uintptr_t)"Key Bindings\n",
 		0,
 		menuhandlerOpenBindsMenu,
+	},
+	{
+		MENUITEMTYPE_SELECTABLE,
+		0,
+		MENUITEMFLAG_SELECTABLE_OPENSDIALOG | MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"Cheats\n",
+		0,
+		(void *)&g_ExtendedCheatsMenuDialog,
 	},
 	{
 		MENUITEMTYPE_SEPARATOR,

--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -23,8 +23,6 @@ u32 g_CheatsEnabledBank1;
 struct menuitem g_CheatsBuddiesMenuItems[];
 struct menudialogdef g_CheatsBuddiesMenuDialog;
 
-#define CHEAT_ALLDOORS_TEXT "All Doors Unlocked\n"
-
 #define TIME(mins, secs) (mins * 60 + secs)
 #define m
 #define s
@@ -108,6 +106,14 @@ struct cheat g_Cheats[] = {
 #endif
 
 };
+
+// Lookup table for custom cheats added to the PC Port
+#ifndef PLATFORM_N64
+static const char *g_CustomCheatNames[] = {
+    [CHEAT_DUALWIELDALLGUNS] = "Dual Wield All Weapons\n",
+    [CHEAT_ALLDOORSUNLOCKED] = "All Doors Unlocked\n",
+};
+#endif
 
 u32 cheatIsUnlocked(s32 cheat_id)
 {
@@ -396,12 +402,7 @@ MenuItemHandlerResult cheatMenuHandleBuddyCheckbox(s32 operation, struct menuite
 char *cheatGetNameIfUnlocked(struct menuitem *item)
 {
 	if (cheatIsUnlocked(item->param)) {
-		if (item->param == CHEAT_ALLDOORSUNLOCKED) {
-			// When retrieving the display name for the "All Doors Unlocked" cheat, directly return its string, as it doesn't exist in the assets used for cheats
-			return CHEAT_ALLDOORS_TEXT;
-		} else {
-			return langGet(g_Cheats[item->param].nametextid);
-		}
+		return cheatGetName(item->param);
 	}
 
 	return langGet(L_MPWEAPONS_074); // "----------"
@@ -514,11 +515,7 @@ char *cheatGetMarquee(struct menuitem *arg0)
 			&& g_Menus[g_MpPlayerNum].curdialog->focuseditem->type == MENUITEMTYPE_CHECKBOX) {
 		cheat_id = g_Menus[g_MpPlayerNum].curdialog->focuseditem->param;
 
-		if (cheat_id == CHEAT_ALLDOORSUNLOCKED) {
-			strcpy(cheatname, CHEAT_ALLDOORS_TEXT);
-		} else {
-			strcpy(cheatname, langGet(g_Cheats[cheat_id].nametextid));
-		}
+		strcpy(cheatname, cheatGetName(cheat_id));
 
 		if (g_Menus[g_MpPlayerNum].curdialog->definition == &g_CheatsBuddiesMenuDialog
 				&& g_Menus[g_MpPlayerNum].curdialog->focuseditem == &g_CheatsBuddiesMenuItems[0]) {
@@ -602,11 +599,7 @@ char *cheatGetMarquee(struct menuitem *arg0)
 			&& g_Menus[g_MpPlayerNum].curdialog->focuseditem->type == MENUITEMTYPE_CHECKBOX) {
 		cheat_id = g_Menus[g_MpPlayerNum].curdialog->focuseditem->param;
 
-		if (cheat_id == CHEAT_ALLDOORSUNLOCKED) {
-			strcpy(cheatname, CHEAT_ALLDOORS_TEXT);
-		} else {
-			strcpy(cheatname, langGet(g_Cheats[cheat_id].nametextid));
-		}
+		strcpy(cheatname, cheatGetName(cheat_id));
 
 		if (g_Menus[g_MpPlayerNum].curdialog->definition == &g_CheatsBuddiesMenuDialog
 				&& g_Menus[g_MpPlayerNum].curdialog->focuseditem == &g_CheatsBuddiesMenuItems[0]) {
@@ -686,11 +679,7 @@ char *cheatGetMarquee(struct menuitem *arg0)
 			&& g_Menus[g_MpPlayerNum].curdialog->focuseditem->type == MENUITEMTYPE_CHECKBOX) {
 		cheat_id = g_Menus[g_MpPlayerNum].curdialog->focuseditem->param;
 
-		if (cheat_id == CHEAT_ALLDOORSUNLOCKED) {
-			strcpy(cheatname, CHEAT_ALLDOORS_TEXT);
-		} else {
-			strcpy(cheatname, langGet(g_Cheats[cheat_id].nametextid));
-		}
+		strcpy(cheatname, cheatGetName(cheat_id));
 
 		if (g_Menus[g_MpPlayerNum].curdialog->definition == &g_CheatsBuddiesMenuDialog
 				&& g_Menus[g_MpPlayerNum].curdialog->focuseditem == &g_CheatsBuddiesMenuItems[0]) {
@@ -880,11 +869,14 @@ s32 cheatGetTime(s32 cheat_id)
 #endif
 
 #if VERSION >= VERSION_NTSC_1_0
-char *cheatGetName(s32 cheat_id)
+const char *cheatGetName(s32 cheat_id)
 {
-	if (cheat_id == CHEAT_ALLDOORSUNLOCKED) {
-		return CHEAT_ALLDOORS_TEXT;
+#ifndef PLATFORM_N64
+	// If the cheat's one of the custom cheats added to the PC port, look up the string literal directly
+    if (g_CustomCheatNames[cheat_id]) {
+        return g_CustomCheatNames[cheat_id];
 	}
+#endif
 	return langGet(g_Cheats[cheat_id].nametextid);
 }
 #endif

--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -514,6 +514,12 @@ char *cheatGetMarquee(struct menuitem *arg0)
 			&& g_Menus[g_MpPlayerNum].curdialog->focuseditem->type == MENUITEMTYPE_CHECKBOX) {
 		cheat_id = g_Menus[g_MpPlayerNum].curdialog->focuseditem->param;
 
+		if (cheat_id == CHEAT_ALLDOORSUNLOCKED) {
+			strcpy(cheatname, CHEAT_ALLDOORS_TEXT);
+		} else {
+			strcpy(cheatname, langGet(g_Cheats[cheat_id].nametextid));
+		}
+
 		if (g_Menus[g_MpPlayerNum].curdialog->definition == &g_CheatsBuddiesMenuDialog
 				&& g_Menus[g_MpPlayerNum].curdialog->focuseditem == &g_CheatsBuddiesMenuItems[0]) {
 			// Velvet
@@ -522,11 +528,10 @@ char *cheatGetMarquee(struct menuitem *arg0)
 			// Show cheat name
 			sprintf(g_CheatMarqueeString, "%s %s\n",
 					g_Menus[g_MpPlayerNum].curdialog->definition == &g_CheatsBuddiesMenuDialog ? langGet(L_MPWEAPONS_143) : langGet(L_MPWEAPONS_136), // "Buddy Available", "Cheat available"
-					langGet(g_Cheats[cheat_id].nametextid)
+					cheatname
 			);
 		} else {
 			// Locked
-			strcpy(cheatname, langGet(g_Cheats[cheat_id].nametextid));
 			ptr = cheatname;
 
 			while (*ptr != '\n') {
@@ -597,6 +602,12 @@ char *cheatGetMarquee(struct menuitem *arg0)
 			&& g_Menus[g_MpPlayerNum].curdialog->focuseditem->type == MENUITEMTYPE_CHECKBOX) {
 		cheat_id = g_Menus[g_MpPlayerNum].curdialog->focuseditem->param;
 
+		if (cheat_id == CHEAT_ALLDOORSUNLOCKED) {
+			strcpy(cheatname, CHEAT_ALLDOORS_TEXT);
+		} else {
+			strcpy(cheatname, langGet(g_Cheats[cheat_id].nametextid));
+		}
+
 		if (g_Menus[g_MpPlayerNum].curdialog->definition == &g_CheatsBuddiesMenuDialog
 				&& g_Menus[g_MpPlayerNum].curdialog->focuseditem == &g_CheatsBuddiesMenuItems[0]) {
 			// Velvet
@@ -605,11 +616,10 @@ char *cheatGetMarquee(struct menuitem *arg0)
 			// Show cheat name
 			sprintf(g_CheatMarqueeString, "%s: %s\n",
 					g_Menus[g_MpPlayerNum].curdialog->definition == &g_CheatsBuddiesMenuDialog ? langGet(L_MPWEAPONS_143) : langGet(L_MPWEAPONS_136), // "Buddy Available", "Cheat available"
-					langGet(g_Cheats[cheat_id].nametextid)
+					cheatname
 			);
 		} else {
 			// Locked
-			strcpy(cheatname, langGet(g_Cheats[cheat_id].nametextid));
 			ptr = cheatname;
 
 			while (*ptr != '\n') {

--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -1110,27 +1110,6 @@ struct menuitem g_CheatsGameplayMenuItems[] = {
 		0,
 		cheatCheckboxMenuHandler,
 	},
-#ifndef PLATFORM_N64
-	{
-		MENUITEMTYPE_CHECKBOX,
-		CHEAT_DUALWIELDALLGUNS,
-		0,
-		(uintptr_t)&cheatGetNameIfUnlocked,
-		0,
-		cheatCheckboxMenuHandler,
-	},
-#if (VERSION == VERSION_NTSC_1_0) || (VERSION == VERSION_NTSC_FINAL)
-// Only enable "All Doors Unlocked" cheat on NTSC 1.0 or final, as the cheat text is not localized
-	{
-		MENUITEMTYPE_CHECKBOX,
-		CHEAT_ALLDOORSUNLOCKED,
-		0,
-		(uintptr_t)&cheatGetNameIfUnlocked,
-		0,
-		cheatCheckboxMenuHandler,
-	},
-#endif
-#endif
 	{
 		MENUITEMTYPE_SEPARATOR,
 		0,
@@ -1584,6 +1563,72 @@ struct menudialogdef g_CheatsBuddiesMenuDialog = {
 	g_CheatsBuddiesMenuItems,
 	cheatMenuHandleDialog,
 	0,
+	NULL,
+};
+
+struct menuitem g_ExtendedCheatsMenuItems[] = {
+	#ifndef PLATFORM_N64
+	{
+		MENUITEMTYPE_CHECKBOX,
+		CHEAT_DUALWIELDALLGUNS,
+		0,
+		(uintptr_t)&cheatGetNameIfUnlocked,
+		0,
+		cheatCheckboxMenuHandler,
+	},
+#if (VERSION == VERSION_NTSC_1_0) || (VERSION == VERSION_NTSC_FINAL)
+// Only enable "All Doors Unlocked" cheat on NTSC 1.0 or final, as the cheat text is not localized
+	{
+		MENUITEMTYPE_CHECKBOX,
+		CHEAT_ALLDOORSUNLOCKED,
+		0,
+		(uintptr_t)&cheatGetNameIfUnlocked,
+		0,
+		cheatCheckboxMenuHandler,
+	},
+#endif
+#endif
+	{
+		MENUITEMTYPE_SEPARATOR,
+		0,
+		0,
+		0x00000096,
+		0,
+		NULL,
+	},
+	{
+		MENUITEMTYPE_MARQUEE,
+		0,
+		MENUITEMFLAG_SMALLFONT | MENUITEMFLAG_MARQUEE_FADEBOTHSIDES,
+		(uintptr_t)&cheatGetMarquee,
+		0,
+		NULL,
+	},
+	{
+		MENUITEMTYPE_SEPARATOR,
+		0,
+		0,
+		0x00000096,
+		0,
+		NULL,
+	},
+	{
+		MENUITEMTYPE_SELECTABLE,
+		0,
+		MENUITEMFLAG_SELECTABLE_CLOSESDIALOG | MENUITEMFLAG_SELECTABLE_CENTRE,
+		L_MPMENU_477, // "Done"
+		0,
+		NULL,
+	},
+	{ MENUITEMTYPE_END },
+};
+
+struct menudialogdef g_ExtendedCheatsMenuDialog = {
+	MENUDIALOGTYPE_DEFAULT,
+	(uintptr_t)"Extended Cheats",
+	g_ExtendedCheatsMenuItems,
+	NULL,
+	MENUDIALOGFLAG_LITERAL_TEXT,
 	NULL,
 };
 

--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -23,6 +23,8 @@ u32 g_CheatsEnabledBank1;
 struct menuitem g_CheatsBuddiesMenuItems[];
 struct menudialogdef g_CheatsBuddiesMenuDialog;
 
+#define CHEAT_ALLDOORS_TEXT "All Doors Unlocked\n"
+
 #define TIME(mins, secs) (mins * 60 + secs)
 #define m
 #define s
@@ -102,7 +104,9 @@ struct cheat g_Cheats[] = {
 	{ L_MPWEAPONS_116, WEAPON_RCP45,      0,                             0,       CHEATFLAG_FIRINGRANGE                        }, // RC-P45
 #ifndef PLATFORM_N64
 	{ L_MPWEAPONS_215, 0,                 SOLOSTAGEINDEX_EXTRACTION,     DIFF_A,  CHEATFLAG_COMPLETION                         }, // Dual wield all guns
+	{ L_MPWEAPONS_073, 0,                 SOLOSTAGEINDEX_EXTRACTION,     DIFF_A,  CHEATFLAG_COMPLETION                         }, // All doors unlocked 
 #endif
+
 };
 
 u32 cheatIsUnlocked(s32 cheat_id)
@@ -392,7 +396,12 @@ MenuItemHandlerResult cheatMenuHandleBuddyCheckbox(s32 operation, struct menuite
 char *cheatGetNameIfUnlocked(struct menuitem *item)
 {
 	if (cheatIsUnlocked(item->param)) {
-		return langGet(g_Cheats[item->param].nametextid);
+		if (item->param == CHEAT_ALLDOORSUNLOCKED) {
+			// When retrieving the display name for the "All Doors Unlocked" cheat, directly return its string, as it doesn't exist in the assets used for cheats
+			return CHEAT_ALLDOORS_TEXT;
+		} else {
+			return langGet(g_Cheats[item->param].nametextid);
+		}
 	}
 
 	return langGet(L_MPWEAPONS_074); // "----------"
@@ -667,6 +676,12 @@ char *cheatGetMarquee(struct menuitem *arg0)
 			&& g_Menus[g_MpPlayerNum].curdialog->focuseditem->type == MENUITEMTYPE_CHECKBOX) {
 		cheat_id = g_Menus[g_MpPlayerNum].curdialog->focuseditem->param;
 
+		if (cheat_id == CHEAT_ALLDOORSUNLOCKED) {
+			strcpy(cheatname, CHEAT_ALLDOORS_TEXT);
+		} else {
+			strcpy(cheatname, langGet(g_Cheats[cheat_id].nametextid));
+		}
+
 		if (g_Menus[g_MpPlayerNum].curdialog->definition == &g_CheatsBuddiesMenuDialog
 				&& g_Menus[g_MpPlayerNum].curdialog->focuseditem == &g_CheatsBuddiesMenuItems[0]) {
 			// Velvet
@@ -675,11 +690,10 @@ char *cheatGetMarquee(struct menuitem *arg0)
 			// Show cheat name
 			sprintf(g_CheatMarqueeString, "%s: %s\n",
 					g_Menus[g_MpPlayerNum].curdialog->definition == &g_CheatsBuddiesMenuDialog ? langGet(L_MPWEAPONS_143) : langGet(L_MPWEAPONS_136), // "Buddy Available", "Cheat available"
-					langGet(g_Cheats[cheat_id].nametextid)
+					cheatname
 			);
 		} else {
 			// Locked
-			strcpy(cheatname, langGet(g_Cheats[cheat_id].nametextid));
 			ptr = cheatname;
 
 			while (*ptr != '\n') {
@@ -858,6 +872,9 @@ s32 cheatGetTime(s32 cheat_id)
 #if VERSION >= VERSION_NTSC_1_0
 char *cheatGetName(s32 cheat_id)
 {
+	if (cheat_id == CHEAT_ALLDOORSUNLOCKED) {
+		return CHEAT_ALLDOORS_TEXT;
+	}
 	return langGet(g_Cheats[cheat_id].nametextid);
 }
 #endif
@@ -1102,6 +1119,17 @@ struct menuitem g_CheatsGameplayMenuItems[] = {
 		0,
 		cheatCheckboxMenuHandler,
 	},
+#if (VERSION == VERSION_NTSC_1_0) || (VERSION == VERSION_NTSC_FINAL)
+// Only enable "All Doors Unlocked" cheat on NTSC 1.0 or final, as the cheat text is not localized
+	{
+		MENUITEMTYPE_CHECKBOX,
+		CHEAT_ALLDOORSUNLOCKED,
+		0,
+		(uintptr_t)&cheatGetNameIfUnlocked,
+		0,
+		cheatCheckboxMenuHandler,
+	},
+#endif
 #endif
 	{
 		MENUITEMTYPE_SEPARATOR,

--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -1567,7 +1567,7 @@ struct menudialogdef g_CheatsBuddiesMenuDialog = {
 };
 
 struct menuitem g_ExtendedCheatsMenuItems[] = {
-	#ifndef PLATFORM_N64
+#ifndef PLATFORM_N64
 	{
 		MENUITEMTYPE_CHECKBOX,
 		CHEAT_DUALWIELDALLGUNS,
@@ -1576,8 +1576,6 @@ struct menuitem g_ExtendedCheatsMenuItems[] = {
 		0,
 		cheatCheckboxMenuHandler,
 	},
-#if (VERSION == VERSION_NTSC_1_0) || (VERSION == VERSION_NTSC_FINAL)
-// Only enable "All Doors Unlocked" cheat on NTSC 1.0 or final, as the cheat text is not localized
 	{
 		MENUITEMTYPE_CHECKBOX,
 		CHEAT_ALLDOORSUNLOCKED,
@@ -1586,7 +1584,6 @@ struct menuitem g_ExtendedCheatsMenuItems[] = {
 		0,
 		cheatCheckboxMenuHandler,
 	},
-#endif
 #endif
 	{
 		MENUITEMTYPE_SEPARATOR,

--- a/src/game/propobj.c
+++ b/src/game/propobj.c
@@ -18917,32 +18917,36 @@ s32 hatGetType(struct prop *prop)
 
 bool doorIsUnlocked(struct prop *playerprop, struct prop *doorprop)
 {
-	struct doorobj *door = doorprop->door;
-	bool canopen = false;
-
-	if (door->keyflags == 0) {
-		canopen = true;
-	} else if (invHasKeyFlags(door->keyflags)) {
-		canopen = true;
+	if (cheatIsActive(CHEAT_ALLDOORSUNLOCKED)) {
+		return true;
 	} else {
-		if (posIsInFrontOfDoor(&playerprop->pos, door)) {
-			if ((door->base.flags2 & OBJFLAG2_LOCKEDBACK)
-					&& (door->base.flags2 & OBJFLAG2_LOCKEDFRONT) == 0) {
-				canopen = true;
-			}
+		struct doorobj *door = doorprop->door;
+		bool canopen = false;
+
+		if (door->keyflags == 0) {
+			canopen = true;
+		} else if (invHasKeyFlags(door->keyflags)) {
+			canopen = true;
 		} else {
-			if ((door->base.flags2 & OBJFLAG2_LOCKEDBACK) == 0
-					&& (door->base.flags2 & OBJFLAG2_LOCKEDFRONT)) {
-				canopen = true;
+			if (posIsInFrontOfDoor(&playerprop->pos, door)) {
+				if ((door->base.flags2 & OBJFLAG2_LOCKEDBACK)
+						&& (door->base.flags2 & OBJFLAG2_LOCKEDFRONT) == 0) {
+					canopen = true;
+				}
+			} else {
+				if ((door->base.flags2 & OBJFLAG2_LOCKEDBACK) == 0
+						&& (door->base.flags2 & OBJFLAG2_LOCKEDFRONT)) {
+					canopen = true;
+				}
 			}
 		}
-	}
 
-	if (!doorIsPadlockFree(door)) {
-		canopen = false;
-	}
+		if (!doorIsPadlockFree(door)) {
+			canopen = false;
+		}
 
-	return canopen;
+		return canopen;
+	}
 }
 
 bool doorIsPosInRange(struct doorobj *door, struct coord *pos, f32 distance, bool isbike)

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -451,6 +451,7 @@
 #define CHEAT_AR53                   40
 #define CHEAT_RCP45                  41
 #define CHEAT_DUALWIELDALLGUNS       42
+#define CHEAT_ALLDOORSUNLOCKED       43
 
 #define CHEATFLAG_TIMED       0
 #define CHEATFLAG_ALWAYSON    1

--- a/src/include/game/cheats.h
+++ b/src/include/game/cheats.h
@@ -24,7 +24,7 @@ char *cheatGetMarquee(struct menuitem *item);
 s32 cheatGetByTimedStageIndex(s32 stage_index, s32 difficulty);
 s32 cheatGetByCompletedStageIndex(s32 stage_index);
 s32 cheatGetTime(s32 cheat_id);
-char *cheatGetName(s32 cheat_id);
+const char *cheatGetName(s32 cheat_id);
 MenuDialogHandlerResult cheatMenuHandleDialog(s32 operation, struct menudialogdef *dialogdef, union handlerdata *data);
 MenuItemHandlerResult cheatCheckboxMenuHandler(s32 operation, struct menuitem *item, union handlerdata *data);
 MenuItemHandlerResult cheatMenuHandleBuddyCheckbox(s32 operation, struct menuitem *item, union handlerdata *data);

--- a/src/include/game/cheats.h
+++ b/src/include/game/cheats.h
@@ -11,6 +11,7 @@ extern struct menudialogdef g_CheatsSoloWeaponsMenuDialog;
 extern struct menudialogdef g_CheatsClassicWeaponsMenuDialog;
 extern struct menudialogdef g_CheatsWeaponsMenuDialog;
 extern struct menudialogdef g_CheatsBuddiesMenuDialog;
+extern struct menudialogdef g_ExtendedCheatsMenuDialog;
 
 u32 cheatIsUnlocked(s32 cheat_id);
 bool cheatIsActive(s32 cheat_id);

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -2821,6 +2821,7 @@ struct player {
 #ifndef PLATFORM_N64
 	/*0x1c74*/ f32 swivelpos[2];
 #endif
+	/*0x1c78*/ bool alldoorsunlocked; // for the "All Doors Unlocked" cheat
 };
 
 struct ailist {


### PR DESCRIPTION
Hi! 

This PR adds a basic "Unlock all doors" cheat to the game,

I initially prepared this patch a year ago just for my own fun while I played Perfect Dark on PC, as I was always interested in the various doors in Perfect Dark that were locked and had no key. I opted to create a new cheat inspired by the "Dual Weapons" cheat that was added to the PC port.

The way the cheat works is fairly straightforward, when it's enabled, whenever a new level is loaded, the game ignores all locked door checks in that level. It does this, by adding a check for the cheat's enablement to `doorIsUnlocked()` in `src/propobj.c`. When the cheat is enabled, this function always returns true, otherwise the function's existing logic is used.

Unlike the dual weapons cheat, I struggled to find a good way to add the cheat text to the game. I tried to use the existing "Door unlocked" string present in the game, but it didn't work as it didn't seem to be loaded when accessing the cheat menu. Instead, I opted to just hardcode the cheat text as a constant in cheats.c (see https://github.com/johnmcollier/perfect_dark/blob/fd737351a7f97249d71cc8668858ab9430c87e47/src/game/cheats.c#L26). I'm still relatively new to the source code here, so I'm sure there's other/better ways to handle this, let me know.

For an example of the cheat in action, see here: https://streamable.com/1ifx8m

Anyways, let me know if this is an okay patch to include!

Edit:

Based on PR feedback, I've also included a new "Extras" cheat menu to put the cheat under, and any potential new cheats added to the PC port (like dual weapons).
