### PR TITLE
Rumble Vibration Filtering support

### DIFF
--- a/port/include/input.h
+++ b/port/include/input.h
@@ -205,6 +205,11 @@ void inputRumble(s32 idx, f32 strength, f32 time);
 f32 inputRumbleGetStrength(s32 cidx);
 void inputRumbleSetStrength(s32 cidx, f32 val);
 
+// Filter out rumble intensity
+// Best for gyro aim or simultaneous gamepad+kb/mouse input
+s32 inputRumbleGetFilter(s32 cidx);
+void inputRumbleSetFilter(s32 cidx, s32 val);
+
 // locks the mouse cursor in the window and makes it invisible if argument is true
 void inputLockMouse(s32 lock);
 

--- a/port/src/input.c
+++ b/port/src/input.c
@@ -36,6 +36,7 @@ static SDL_GameController *pads[INPUT_MAX_CONTROLLERS];
 #define CONTROLLERCFG_DEFAULT { \
 	.rumbleOn = 0, \
 	.rumbleScale = 0.5f, \
+	.rumbleFilter = -1, \
 	.axisMap = { \
 		{ SDL_CONTROLLER_AXIS_LEFTX,  SDL_CONTROLLER_AXIS_LEFTY  }, \
 		{ SDL_CONTROLLER_AXIS_RIGHTX, SDL_CONTROLLER_AXIS_RIGHTY }, \
@@ -51,6 +52,7 @@ static SDL_GameController *pads[INPUT_MAX_CONTROLLERS];
 static struct controllercfg {
 	s32 rumbleOn;
 	f32 rumbleScale;
+	s32 rumbleFilter;
 	u32 axisMap[2][2];
 	f32 sens[4];
 	s32 deadzone[4];
@@ -966,6 +968,16 @@ void inputRumbleSetStrength(s32 cidx, f32 val)
 	padsCfg[cidx].rumbleScale = val;
 }
 
+s32 inputRumbleGetFilter(s32 cidx)
+{
+	return padsCfg[cidx].rumbleFilter;
+}
+
+void inputRumbleSetFilter(s32 cidx, s32 val)
+{
+	padsCfg[cidx].rumbleFilter = val;
+}
+
 s32 inputControllerMask(void)
 {
 	return connectedMask;
@@ -1524,6 +1536,7 @@ PD_CONSTRUCTOR static void inputConfigInit(void)
 		secname[12] = '1' + c;
 		secname[13] = '\0';
 		configRegisterFloat(strFmt("%s.RumbleScale", secname), &padsCfg[c].rumbleScale, 0.f, 1.f);
+		configRegisterInt(strFmt("%s.RumbleFilter", secname), &padsCfg[c].rumbleFilter, -1, 1);
 		configRegisterInt(strFmt("%s.LStickDeadzoneX", secname), &padsCfg[c].deadzone[0], 0, 32767);
 		configRegisterInt(strFmt("%s.LStickDeadzoneY", secname), &padsCfg[c].deadzone[1], 0, 32767);
 		configRegisterInt(strFmt("%s.RStickDeadzoneX", secname), &padsCfg[c].deadzone[2], 0, 32767);

--- a/port/src/input.c
+++ b/port/src/input.c
@@ -946,15 +946,28 @@ void inputRumble(s32 idx, f32 strength, f32 time)
 	}
 
 	if (padsCfg[idx].rumbleOn) {
+		s32 filterSetting = padsCfg[idx].rumbleFilter;
+		
+		// Apply user's rumble scale
 		strength *= padsCfg[idx].rumbleScale;
+		
 		if (strength <= 0.f) {
 			strength = 0.f;
 			time = 0.f;
-		} else {
-			strength *= 65535.f;
-			time *= 1000.f;
 		}
-		SDL_GameControllerRumble(pads[idx], (u16)strength, (u16)strength, (u32)time);
+		
+		u16 lowFreq = (u16)(strength * 65535.f);
+		u16 highFreq = (u16)(strength * 65535.f);
+		
+		// Apply filter to reduce rumble intensity when enabled
+		if (filterSetting == 1) {
+			lowFreq = (u16)(lowFreq * 0.20f);           // 20% of original
+			highFreq = (u16)(strength * 65535.f * 0.08f); // 8% of original (recalculate from strength)
+		}
+		
+		u32 duration = (u32)(time * 1000.f);
+		
+		SDL_GameControllerRumble(pads[idx], lowFreq, highFreq, duration);
 	}
 }
 

--- a/port/src/libultra.c
+++ b/port/src/libultra.c
@@ -248,10 +248,10 @@ s32 __osMotorAccess(OSPfs *pfs, s32 cmd)
 		return PFS_ERR_NOPACK;
 	}
 
-	s32 filterSetting = inputRumbleGetFilter(pfs->channel);
+	s32 filterSetting = inputRumbleGetFilter(pfs->channel); // filters rumble strength
 	f32 strength = (f32)(cmd == MOTOR_START);
 	
-	if (filterSetting > 0) {
+	if (filterSetting == 1) {
 		strength *= 0.30f;
 	}
 	

--- a/port/src/libultra.c
+++ b/port/src/libultra.c
@@ -248,13 +248,7 @@ s32 __osMotorAccess(OSPfs *pfs, s32 cmd)
 		return PFS_ERR_NOPACK;
 	}
 
-	s32 filterSetting = inputRumbleGetFilter(pfs->channel); // filters rumble strength
-	f32 strength = (f32)(cmd == MOTOR_START);
-	
-	if (filterSetting == 1) {
-		strength *= 0.30f;
-	}
-	
+	const f32 strength = (f32)(cmd == MOTOR_START);
 	inputRumble(pfs->channel, strength, 5.f); // hope someone turns it off in those 5 seconds
 
 	return 0;

--- a/port/src/libultra.c
+++ b/port/src/libultra.c
@@ -248,7 +248,13 @@ s32 __osMotorAccess(OSPfs *pfs, s32 cmd)
 		return PFS_ERR_NOPACK;
 	}
 
-	const f32 strength = (f32)(cmd == MOTOR_START);
+	s32 filterSetting = inputRumbleGetFilter(pfs->channel);
+	f32 strength = (f32)(cmd == MOTOR_START);
+	
+	if (filterSetting > 0) {
+		strength *= 0.30f;
+	}
+	
 	inputRumble(pfs->channel, strength, 5.f); // hope someone turns it off in those 5 seconds
 
 	return 0;


### PR DESCRIPTION
Whenever you use Gyro Aiming, or Mixed Input: the strength of a Rumble or Haptic can affect the ability to stay still while trying to do precise shots. This is actually a rare problem for games like [The Last of Us Part 1/2 Remastered where DualSense's Haptic Feedback being extremely strong that it requires reducing Gun effects](https://www.reddit.com/r/thelastofus/comments/19dteuh/comment/kj8bem1/) to evade it. 

This specific problem becomes more evident with the recently released Battlefield 6, as the Gyro's Recoil patterns is "different" than mouse's pattern...but in reality: [it's the Haptic effects being the culprit](https://www.reddit.com/r/GyroGaming/comments/1o5qlpx/comment/njbeebe/).

Perfect Dark has a similar issue, but far more evident with specific weapons that has a stronger vibration. for this test: I'd be using a DualShock 4 controller with two different grip styles, one that is steady and another will be loosed. Other controllers that has a weaker rumble or Haptic motors won't be able to tell the difference but DualShock 4's the most effective out of the bunch.

https://github.com/user-attachments/assets/c9e561b5-db14-42bc-a8fb-7f44c92fc292

the best workaround would be to reduce the in-game rumble slider to 1, or 0-- but even then: it's still strong at 1.

Since then: I asked one or two people on how to best approach Rumble Filtering, i managed to ask Jibb Smart (Epic Games' Fortnite dev, who handled Gyro/Flick Stick stuffs) about it, this is his response.

> Looks to me like the game needs to sample the gyro more frequently.
>
> The rumble makes the controller turn side-to-side quickly. If they're not sampling frequently enough, it might sample left-turn, left-turn, left-turn, left-turn on one shot, and right-turn, right-turn, right-turn, right-turn on another shot. If the game sampled the gyro at a high enough rate, it would sample multiple parts of the side-to-side rumble happening during a given frame, and they would cancel out.
>
> The Filter Controller Vibration setting in Fortnite is more about reducing the impact of lower-frequency rumble like with the DualShock 4 🙂

thanks to said advice: i figured out how to introduce the Vibration Filtering functionality to the mix! 

https://github.com/user-attachments/assets/1d5e683f-ddd6-4c99-afc6-7845b5e5625d

This PR introduces `RumbleFilter` function that reduces lower-frequency rumble for Controllers (such as DualShock 4), best use in both Gyro Aiming and Simultaneous Inputs/Mixed Input. When enabled: overall Rumble Strength will be reduced by roughly 70%, while maintaining the same rumble slider function.

While this option is hidden in-game, that function can be either enabled or disabled within `pd.ini`. as of this writing: `-1` will be set be default, as that is intended for https://github.com/fgsfdsfgs/perfect_dark/pull/644, for now: `-1` will function the same as `0` (disabled).