### PR TITLE
Lighting fix for Dr Caroll cutscene

### DIFF
--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -1043,7 +1043,7 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 		if (g_Vars.stagenum == 51 && rooms[i] == 100) {
 			// skip BG test during final cutscene of the dataDyne Research
 			// level since the camera clips through the wall, which will
-			// incorrectly remove lights when Dr Carroll first appears.
+			// incorrectly remove lights when Dr Caroll first appears.
 			continue;
 		}
 		if (bgTestHitInRoom(&shotdata.gunpos3d, endpos3d, rooms[i], &sp664)) {

--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -1040,6 +1040,12 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 
 	// Check for BG hits first
 	for (i = 0; rooms[i] != -1; i++) {
+		if (g_Vars.stagenum == 51 && rooms[i] == 100) {
+			// skip BG test during final cutscene of the dataDyne Research
+			// level since the camera clips through the wall, which will
+			// incorrectly remove lights when Dr Carroll first appears.
+			continue;
+		}
 		if (bgTestHitInRoom(&shotdata.gunpos3d, endpos3d, rooms[i], &sp664)) {
 			// check if it's far enough away from the end point
 			if (fabsf(sp664.pos.x - endpos3d->x) >= 0.1f ||

--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -1040,7 +1040,7 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 
 	// Check for BG hits first
 	for (i = 0; rooms[i] != -1; i++) {
-		if (g_Vars.stagenum == 51 && rooms[i] == 100) {
+		if (g_Vars.stagenum == STAGE_INVESTIGATION && rooms[i] == 100) {
 			// skip BG test during final cutscene of the dataDyne Research
 			// level since the camera clips through the wall, which will
 			// incorrectly remove lights when Dr Caroll first appears.


### PR DESCRIPTION
This PR addresses the missing background lights in the cutscene, shown below, where Dr Caroll first appears at the end of dataDyne research.

<img width="500" alt="Screenshot_20251103_200552" src="https://github.com/user-attachments/assets/4d39d282-5499-4d52-ab5d-498322b323d4" />

### Root Cause ###
The missing lights seem to come from placing the camera just outside the level geometry when it cuts to the view with Dr Caroll rising up. This can be seen in the figure below, which plots the camera position (green) relative to the light locations (blue) on the back wall of the cutscene. The line-of-sight test for light visibility intersects background hit locations (orange) very close to the camera location. The camera is probably just outside of the right wall in the room that Joanna approaches to find Dr Caroll.

<img width="400" alt="Screenshot_20251103_201418" src="https://github.com/user-attachments/assets/55ddeedf-95b1-47df-b8cf-811c1801fd25" />

### Solution ###
Given that the room (number 100 in stagenum 51) with these lights is only accessible via a cutscene, I added an exception for it within the line-of-sight test for light visibility. The exception ignores the background hit test for lights in this stagenum + room.

The image below shows that this change correctly renders these lights in this portion of the cutscene. The lights are correctly blocked by the prop geometry in the rest of the cutscene.

<img width="500" alt="Screenshot_20251103_200633" src="https://github.com/user-attachments/assets/73f59181-22fa-4db2-b20d-eabf8b1c9187" />


