### PR TITLE
Possible solution for missing light fixtures

### DIFF
--- a/src/game/bg.c
+++ b/src/game/bg.c
@@ -136,6 +136,25 @@ s32 g_BgNumRoomLoadCandidates = 0;
 u16 g_BgFrameCount = 0xfffe;
 s32 g_BgNumPortalCameraCacheItems = 0;
 
+#ifndef PLATFORM_N64
+
+void bgAdjustLightPosition(s32 roomnum, s32 lightnum, s16 dx, s16 dy, s16 dz)
+{
+	s32 i;
+	struct light *roomlights;
+
+	bgLoadRoom(roomnum);
+	roomlights = (struct light *)&g_BgLightsFileData[g_Rooms[roomnum].gfxdata->lightsindex * 0x22];
+
+	for (i = 0; i < 4; i++) {
+		roomlights[lightnum].bbox[i].x += dx;
+		roomlights[lightnum].bbox[i].y += dy;
+		roomlights[lightnum].bbox[i].z += dz;
+	}
+}
+
+#endif
+
 void bgUnpausePropsInRoom(u32 roomnum, bool tintedglassonly)
 {
 	struct prop *prop;
@@ -2058,6 +2077,28 @@ void bgBuildTables(s32 stagenum)
 
 #if VERSION < VERSION_NTSC_1_0
 	bgBuildReferenceLightSums();
+#endif
+
+#ifndef PLATFORM_N64
+	switch (stagenum) {
+		case STAGE_INVESTIGATION:
+			bgAdjustLightPosition(21, 0,  0, -1,  0);
+			bgAdjustLightPosition(46, 0,  0, -1,  0);
+			bgAdjustLightPosition(47, 0,  0, -1,  0);
+			bgAdjustLightPosition(52, 0,  0, -1,  0);
+			bgAdjustLightPosition(53, 0,  0, -1,  0);
+			bgAdjustLightPosition(62, 0,  0, -1,  0);
+			bgAdjustLightPosition(71, 0,  0, -1,  0);
+			bgAdjustLightPosition(73, 0,  0, -1,  0);
+			bgAdjustLightPosition(74, 0,  0, -1,  0);
+			bgAdjustLightPosition(75, 0,  0, -1,  0);
+			bgAdjustLightPosition(76, 0,  0, -1,  0);
+			bgAdjustLightPosition(77, 0,  0, -1,  0);
+			bgAdjustLightPosition(98, 0,  0, -1,  0);
+			bgAdjustLightPosition(80, 3, -1,  0, +1);
+		default:
+			break;
+	}
 #endif
 }
 

--- a/src/game/bg.c
+++ b/src/game/bg.c
@@ -2095,7 +2095,7 @@ void bgBuildTables(s32 stagenum)
 			bgAdjustLightPosition(76, 0,  0, -1,  0);
 			bgAdjustLightPosition(77, 0,  0, -1,  0);
 			bgAdjustLightPosition(98, 0,  0, -1,  0);
-			bgAdjustLightPosition(80, 3, -1,  0, +1);
+			bgAdjustLightPosition(80, 3, -1,  0,  0);
 		default:
 			break;
 	}


### PR DESCRIPTION
This PR contains a possible solution for some of the missing lights in certain levels. The idea is to shift the position of problematic lights slightly so they pass the line-of-sight test for visibility. This is needed since the original position is  very close or just behind the background geometry, which fails the line-of-sight test.

The shift is performed inside bgBuildTables, which is only called when loading background data at the beginning of the level. It should not impact performance once the player is in the level. The shifts are small enough (the minimum size of 1 allowed by the vec3s16 light position) that they should be indistinguishable from the original light position.

So far I've implemented fixes for lights in dataDyne Research: Investigation since it had the largest number of missing lights on my playthrough. I included comparison images below. I can add fixes for additional levels if you approve of this approach. 

### Images from PC port ###
Broken lights from dataDyne Research: Investigation in the current PC port

<img width="200" alt="pc_room21_light0" src="https://github.com/user-attachments/assets/0d455eec-c922-4517-81e7-2b88539cf14e" />
<img width="200"  alt="pc_room46_47_light0" src="https://github.com/user-attachments/assets/e52b875b-de61-434b-aaf7-656f76bcbe3b" />
<img width="200" alt="pc_room52_light0" src="https://github.com/user-attachments/assets/9e6a4df4-7a64-4074-a484-1ddb8c4fd3ff" />
<img width="200" alt="pc_room53_light0" src="https://github.com/user-attachments/assets/6d9972c7-c86f-4ca7-9a22-2e1470ef7418" />
<img width="200" alt="pc_room62_light0" src="https://github.com/user-attachments/assets/2e678d37-1725-441e-ae09-deef3276a41e" />
<img width="200" alt="pc_room71_light0" src="https://github.com/user-attachments/assets/7f0643a2-2d32-4b4b-b8b9-ed86a393ba2e" />
<img width="200" alt="pc_room73_light0" src="https://github.com/user-attachments/assets/1431ca51-c89e-490f-8137-c95199c43cc6" />
<img width="200" alt="pc_room74_light0" src="https://github.com/user-attachments/assets/7fc77c13-4b55-4f57-ab3e-abd5cc5a3e6c" />
<img width="200" alt="pc_room75_76_light0" src="https://github.com/user-attachments/assets/a037bf98-60bc-4f71-becb-d80e4ec04de9" />
<img width="200" alt="pc_room77_light0" src="https://github.com/user-attachments/assets/a8a6668a-a964-45a6-ab17-fd1d6a3f8062" />
<img width="200" alt="pc_room80_light3" src="https://github.com/user-attachments/assets/9b370c8c-69a3-4d01-8da1-a453f50c005f" />
<img width="200" alt="pc_room98_light0" src="https://github.com/user-attachments/assets/0ac0bfa8-0478-4cbe-9a81-0698a810c6f5" />

### Images from this PR ###
Fixed lights after adjusting positions with this PR

<img width="200" alt="pr_room21_light0" src="https://github.com/user-attachments/assets/4e825279-f98d-460a-a2ce-056892877946" />
<img width="200" alt="pr_room46_47_light0" src="https://github.com/user-attachments/assets/506a1b49-f5e3-4855-b1d7-6b86f8d0de51" />
<img width="200" alt="pr_room52_light0" src="https://github.com/user-attachments/assets/7915c444-e54e-4eb7-aa5a-3da22ce0c1dd" />
<img width="200" alt="pr_room53_light0" src="https://github.com/user-attachments/assets/1e254170-a35e-45bd-9540-c217c154d95a" />
<img width="200" alt="pr_room62_light0" src="https://github.com/user-attachments/assets/73cc8faa-b19e-4b44-9c51-5f53f3685705" />
<img width="200" alt="pr_room71_light0" src="https://github.com/user-attachments/assets/6e2fc03f-0f3a-4919-8e3f-71520264b195" />
<img width="200" alt="pr_room73_light0" src="https://github.com/user-attachments/assets/4b8df72f-c0fd-40f1-9e39-c457a74cdd8f" />
<img width="200" alt="pr_room74_light0" src="https://github.com/user-attachments/assets/4567642a-9a00-4fe5-b5b6-6eae427dd068" />
<img width="200" alt="pr_room75_76_light0" src="https://github.com/user-attachments/assets/15065b39-f8af-4de9-9903-a92054993530" />
<img width="200" alt="pr_room77_light0" src="https://github.com/user-attachments/assets/9673009d-9296-4ec6-aa46-d1abb6659fa7" />
<img width="200" alt="pr_room80_light3" src="https://github.com/user-attachments/assets/49e31a52-5d26-49c0-9edb-c9861d83ef85" />
<img width="200" alt="pr_room98_light0" src="https://github.com/user-attachments/assets/d9a1357f-7eca-4c7f-bf95-2837e338513a" />

