### PR TITLE
Fix for background lights

### DIFF
--- a/src/game/bg.c
+++ b/src/game/bg.c
@@ -4590,6 +4590,10 @@ bool bgTestHitInRoom(struct coord *frompos, struct coord *topos, s32 roomnum, st
 	numbatches = g_Rooms[roomnum].numvtxbatches;
 
 	for (i = 0; i < numbatches; batch++, i++) {
+#ifndef PLATFORM_N64
+		if (hitthing->ignore_xlu && batch->type == VTXBATCHTYPE_XLU)
+			continue;
+#endif
 		j = bg0f1612e4(&batch->bbmin, &batch->bbmax, &from, &dist, &sp94, &hitthing->pos);
 
 		if (j == 0) {

--- a/src/game/bg.c
+++ b/src/game/bg.c
@@ -135,6 +135,9 @@ s32 g_BgMostAttemptedDrawSlots = 0;
 s32 g_BgNumRoomLoadCandidates = 0;
 u16 g_BgFrameCount = 0xfffe;
 s32 g_BgNumPortalCameraCacheItems = 0;
+#ifndef PLATFORM_N64
+bool g_BgHitXluDisabled = false;
+#endif
 
 void bgUnpausePropsInRoom(u32 roomnum, bool tintedglassonly)
 {
@@ -4591,7 +4594,7 @@ bool bgTestHitInRoom(struct coord *frompos, struct coord *topos, s32 roomnum, st
 
 	for (i = 0; i < numbatches; batch++, i++) {
 #ifndef PLATFORM_N64
-		if (hitthing->ignore_xlu && batch->type == VTXBATCHTYPE_XLU)
+		if (g_BgHitXluDisabled && batch->type == VTXBATCHTYPE_XLU)
 			continue;
 #endif
 		j = bg0f1612e4(&batch->bbmin, &batch->bbmax, &from, &dist, &sp94, &hitthing->pos);
@@ -6421,6 +6424,10 @@ void bgCalculateGlaresForVisibleRooms(void)
 
 	g_NumRoomsWithGlares = 0;
 
+	// disable line-of-sight hits for transparent background
+	// surfaces before testing for light obstructions
+	g_BgHitXluDisabled = true;
+
 	if (!g_Vars.mplayerisrunning) {
 		for (i = 1; i < g_Vars.roomcount; i++) {
 			if (g_Rooms[i].flags & ROOMFLAG_ONSCREEN) {
@@ -6431,6 +6438,9 @@ void bgCalculateGlaresForVisibleRooms(void)
 			}
 		}
 	}
+
+	// re-enable background hits for transparent surfaces
+	g_BgHitXluDisabled = false;
 }
 
 #endif

--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -993,9 +993,6 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 	RoomNum *roomsptr;
 	struct prop *prop;
 
-	// ignore transparent surfaces
-	hitthing.ignore_xlu = 1;
-
 	shotdata.gunpos3d.x = gunpos3d->x;
 	shotdata.gunpos3d.y = gunpos3d->y;
 	shotdata.gunpos3d.z = gunpos3d->z;

--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -983,7 +983,7 @@ struct prop *shotCalculateHits(s32 handnum, bool isshooting, struct coord *gunpo
 bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *gunpos3d, struct coord *gundir3d, struct coord *endpos3d)
 {
 	struct prop **propptr;
-	struct hitthing sp664;
+	struct hitthing hitthing;
 	struct coord delta;
 	struct shotdata shotdata;
 	s32 i;
@@ -992,6 +992,9 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 	RoomNum spb8[8];
 	RoomNum *roomsptr;
 	struct prop *prop;
+
+	// ignore transparent surfaces
+	hitthing.ignore_xlu = 1;
 
 	shotdata.gunpos3d.x = gunpos3d->x;
 	shotdata.gunpos3d.y = gunpos3d->y;
@@ -1040,11 +1043,11 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 
 	// Check for BG hits first
 	for (i = 0; rooms[i] != -1; i++) {
-		if (bgTestHitInRoom(&shotdata.gunpos3d, endpos3d, rooms[i], &sp664)) {
+		if (bgTestHitInRoom(&shotdata.gunpos3d, endpos3d, rooms[i], &hitthing)) {
 			// check if it's far enough away from the end point
-			if (fabsf(sp664.pos.x - endpos3d->x) >= 0.1f ||
-					fabsf(sp664.pos.y - endpos3d->y) >= 0.1f ||
-					fabsf(sp664.pos.z - endpos3d->z) >= 0.1f) {
+			if (fabsf(hitthing.pos.x - endpos3d->x) >= 0.1f ||
+					fabsf(hitthing.pos.y - endpos3d->y) >= 0.1f ||
+					fabsf(hitthing.pos.z - endpos3d->z) >= 0.1f) {
 				return false;
 			}
 		}

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -5750,6 +5750,9 @@ struct hitthing {
 	s16 unk28;
 	s16 texturenum;
 	s16 unk2c;
+#ifndef PLATFORM_N64
+	s16 ignore_xlu;
+#endif
 };
 
 struct hit {

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -5750,9 +5750,6 @@ struct hitthing {
 	s16 unk28;
 	s16 texturenum;
 	s16 unk2c;
-#ifndef PLATFORM_N64
-	s16 ignore_xlu;
-#endif
 };
 
 struct hit {


### PR DESCRIPTION
This PR updates the line-of-sight test to account for transparent background surfaces when checking for light visibility. Without this, the line-of-sight test incorrectly flags lights as non-visible when they're behind windows in the background geometry.

The change is implemented by adding a `g_BgHitXluDisabled` boolean to `src/game/bg.c`. This value is toggled to `true` when calculating light visibility within `bgCalculateGlaresForVisibleRooms()` to prevent transparent background surfaces from triggering the line-of-sight test for each light. It is returned to `false` after completing the light calculation. This ensures bullet hits still render correctly on glass.

The impact of this change can be seen in the elevator shaft of the Defection level. The current PC port is missing lights on floors below the top 3:

<img width="300" alt="elevator_pc" src="https://github.com/user-attachments/assets/f71f8b57-be08-4085-b09a-1f2c52dc1834" />

whereas this PR correctly renders the floor lights behind the glass windows on each floor:

<img width="300" alt="elevator_pr" src="https://github.com/user-attachments/assets/bd3a19e1-a42d-4030-9e42-3c27f692ab8b" />

final note: I renamed the `sp644` variable to `hitthing` since it was easier to understand the code when debugging `src/game/prop.c`.
