### PR TITLE
Exclude laser doors from lighting line-of-sight test

### DIFF
--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -1066,7 +1066,7 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 			if (prop->type == PROPTYPE_CHR
 					|| (prop->type == PROPTYPE_PLAYER && prop->chr && (g_Vars.in_cutscene || playermgrGetPlayerNumByProp(prop) != g_Vars.currentplayernum))) {
 				chrTestHit(prop, &shotdata, false, true);
-			} else if (prop->type == PROPTYPE_WEAPON || prop->type == PROPTYPE_DOOR
+			} else if (prop->type == PROPTYPE_WEAPON || (prop->type == PROPTYPE_DOOR && ((struct doorobj *)prop->obj)->doortype != DOORTYPE_LASER)
 					|| (prop->type == PROPTYPE_OBJ && prop->obj->type != OBJTYPE_GLASS && prop->obj->type != OBJTYPE_TINTEDGLASS)) {
 				objTestHit(prop, &shotdata);
 			}


### PR DESCRIPTION
This PR excludes laser doors from the line-of-sight test used to determine light visibility. This is needed to replicate the original lighting behavior on the N64 where lights were visible through laser beams, as can be seen in the example image below from the ParaLLEl N64 emulator:

<img height="200" alt="Screenshot 2025-11-22 133400" src="https://github.com/user-attachments/assets/8dc6ff0c-b8a6-40e1-95ee-5896e9b7e3b7" />

Combining this PR with PR #667 successfully reproduces the same lighting behavior as the ParaLLEl N64 emulator for laser doors in the Investigation level:

<img height="200" alt="this_PR_and_PR667" src="https://github.com/user-attachments/assets/3a115d98-c0cb-499e-9a78-504333d0f39a" />


