### PR TITLE
Limit 'Start Armed' option to Combat Simulator

### DIFF
--- a/src/game/bot.c
+++ b/src/game/bot.c
@@ -262,7 +262,8 @@ void botSpawn(struct chrdata *chr, u8 respawning)
 		func0f02e9a0(chr, 0);
 
 #ifndef PLATFORM_N64
-		if ((g_MpSetup.options & MPOPTION_SPAWNWITHWEAPON)
+		if (g_Vars.normmplayerisrunning
+				&& (g_MpSetup.options & MPOPTION_SPAWNWITHWEAPON)
 				&& g_MpSetup.weapons[0] != MPWEAPON_NONE
 				&& g_MpSetup.weapons[0] != MPWEAPON_DISABLED
 				&& g_MpSetup.weapons[0] != MPWEAPON_SHIELD) {

--- a/src/game/player.c
+++ b/src/game/player.c
@@ -1114,7 +1114,8 @@ void playerSpawn(void)
 				invGiveSingleWeapon(WEAPON_NIGHTVISION);
 			}
 
-			if ((g_MpSetup.options & MPOPTION_SPAWNWITHWEAPON)
+			if (g_Vars.normmplayerisrunning
+					&& (g_MpSetup.options & MPOPTION_SPAWNWITHWEAPON)
 					&& g_MpSetup.weapons[0] != MPWEAPON_NONE
 					&& g_MpSetup.weapons[0] != MPWEAPON_DISABLED
 					&& g_MpSetup.weapons[0] != MPWEAPON_SHIELD) {


### PR DESCRIPTION
As mentioned in #673, the `Start Armed` option was carrying over to Co-Op and Counter-Op modes. This only occurred when the sim was human-controlled in Co-Op mode. Checking if we're in Combat Sim mode (`g_Vars.normmplayerisrunning`) resolves this. Performing this check in `src/game/bot.c` isn't strictly necessary to fix this bug, but it more clearly shows the intent that this option is for Combat Sim mode only.