### PR TITLE
fixed Crosshair Swivel conflicting when using Mixed Input

### DIFF
--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -437,6 +437,38 @@ void bmoveUpdateSpeedThetaControl(f32 value)
 }
 
 /**
+ * Apply crosshair swivel based on camera movement with input detection
+ */
+static void bmoveApplyCrosshairSwivel(struct movedata *movedata, f32 mlookscale, f32 *x, f32 *y)
+{
+#ifdef PLATFORM_N64
+	*x = g_Vars.currentplayer->speedtheta * 0.3f + g_Vars.currentplayer->gunextraaimx;
+	*y = -g_Vars.currentplayer->speedverta * 0.1f + g_Vars.currentplayer->gunextraaimy;
+#else
+	f32 xscale, yscale;
+	bool mouse_active = (movedata->freelookdx || movedata->freelookdy);
+	bool joystick_active = (movedata->c1stickxraw != 0 || movedata->c1stickyraw != 0);
+	
+	if ((mouse_active) && joystick_active) {
+		// Mouse + joystick sway
+		xscale = PLAYER_EXTCFG().crosshairsway * 0.80f;  // 80% for precision+joystick sway
+		yscale = PLAYER_EXTCFG().crosshairsway * 0.80f;  // 80% for precision+joystick sway
+	} else if (mouse_active) {
+		// Mouse sway
+		xscale = PLAYER_EXTCFG().crosshairsway * 0.20f;  // 20% for mouse sway
+		yscale = PLAYER_EXTCFG().crosshairsway * 0.30f;  // 30% for mouse sway
+	} else {
+		// Joystick only or no input - full sway
+		xscale = yscale = PLAYER_EXTCFG().crosshairsway;
+	}
+	// Joystick x/y scaling
+	// 0.3f for x, 0.1f for y
+	*x = g_Vars.currentplayer->speedtheta * 0.3f * xscale + g_Vars.currentplayer->gunextraaimx;
+	*y = -g_Vars.currentplayer->speedverta * 0.1f * yscale + g_Vars.currentplayer->gunextraaimy;
+#endif
+}
+
+/**
  * Calculate the lookahead angle.
  *
  * The return value is the intended vertical angle to look at.
@@ -2186,15 +2218,8 @@ void bmoveProcessInput(bool allowc1x, bool allowc1y, bool allowc1buttons, bool i
 			x = g_Vars.currentplayer->speedtheta * 0.3f + g_Vars.currentplayer->gunextraaimx;
 			y = -g_Vars.currentplayer->speedverta * 0.1f + g_Vars.currentplayer->gunextraaimy;
 #else
-			f32 xscale, yscale;
-			if (movedata.freelookdx || movedata.freelookdy) {
-				xscale = PLAYER_EXTCFG().crosshairsway * 0.20f;
-				yscale = PLAYER_EXTCFG().crosshairsway * 0.30f;
-			} else {
-				xscale = yscale = PLAYER_EXTCFG().crosshairsway;
-			}
-			x = g_Vars.currentplayer->speedtheta * 0.3f * xscale + g_Vars.currentplayer->gunextraaimx;
-			y = -g_Vars.currentplayer->speedverta * 0.1f * yscale + g_Vars.currentplayer->gunextraaimy;
+            // Crosshair swivel movement system
+			bmoveApplyCrosshairSwivel(&movedata, mlookscale, &x, &y);
 #endif
 
 			bgunSwivelWithDamp(x, y, PAL ? 0.955f : 0.963f);


### PR DESCRIPTION
when using both Controller's Joystick Camera and Keyboard/Mouse's Mouse Camera at the same time: the Crosshair swivel will start to fight each other. This makes the whole Steam Deck (and soon: Steam Controller (2026)) mixed input experience weird.

This PR is backported from #644, but now is centralized, will make it easier to migrate to https://github.com/fgsfdsfgs/perfect_dark/pull/648 when the time comes