### PR TITLE
Prevent Combat Simulator 'Load Settings' clobber

### DIFF
--- a/src/game/mplayer/mplayer.c
+++ b/src/game/mplayer/mplayer.c
@@ -601,7 +601,7 @@ void mpInit(bool resetplayers)
 	g_MpSetup.chrslots = 0;
 
 	for (i = 0; i < ARRAYCOUNT(g_Menus); i++) {
-		g_Menus[i].mpsetup.showpresets = 1;
+		g_Menus[i].mpsetupext.showpresets = 1;
 	}
 
 #ifndef PLATFORM_N64

--- a/src/game/mplayer/setup.c
+++ b/src/game/mplayer/setup.c
@@ -2258,7 +2258,7 @@ MenuItemHandlerResult mpPlayerNameMenuHandler(s32 operation, struct menuitem *it
 
 MenuItemHandlerResult mpLoadSettingsMenuHandler(s32 operation, struct menuitem *item, union handlerdata *data)
 {
-	u8 presets = g_Menus[g_MpPlayerNum].mpsetup.showpresets;
+	u8 presets = g_Menus[g_MpPlayerNum].mpsetupext.showpresets;
 	s32 numpresets = mpGetNumUnlockedPresets()*presets;
 
 	switch (operation) {
@@ -2568,8 +2568,8 @@ MenuDialogHandlerResult mpLoadSettingsDialogHandler(s32 operation, struct menudi
 {
 	if (operation == MENUOP_TICK) {
 		if (menuAltAnyPressed(g_MpPlayerNum)) {
-			u8 presets = g_Menus[g_MpPlayerNum].mpsetup.showpresets;
-			g_Menus[g_MpPlayerNum].mpsetup.showpresets = 1 - presets;
+			u8 presets = g_Menus[g_MpPlayerNum].mpsetupext.showpresets;
+			g_Menus[g_MpPlayerNum].mpsetupext.showpresets = 1 - presets;
 		}
 	}
 }

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -3777,8 +3777,9 @@ struct menudata_mpsetup {
 	u32 slotindex;
 	u32 slotcount;
 	u32 unke24;
-	u32 unke28;
-	u32 unke2c;
+};
+
+struct menudata_mpsetup_ext {
 	u8 showpresets;
 };
 
@@ -3995,6 +3996,7 @@ struct menu {
 		struct menudata_mpsetup mpsetup;
 	};
 
+	struct menudata_mpsetup_ext mpsetupext;
 };
 
 struct gamefile {


### PR DESCRIPTION
While I wasn't able to reproduce this bug exactly as shown in the video in #652, I was able to produce a crash by starting a CS match, picking up a weapon and switching to it, exiting the CS match, and scrolling through the `Load Settings` menu. This should fix #652, since I believe the cause is related to the following:

`g_Menus[g_MpPlayerNum].training.weaponnum` and `g_Menus[g_MpPlayerNum].mpsetup.showpresets` share the same address. In Combat Simulator, when the game is paused, `g_Menus[g_MpPlayerNum].training.weaponnum` is modified (and thus `g_Menus[g_MpPlayerNum].mpsetup.showpresets` as well). So, when `numpresets` is calculated in `mpLoadSettingsMenuHandler` function, the number of unlocked presets is actually being multiplied by whatever the player's weapon number was in the prior CS match. This causes the `Load Settings` list to become much larger than it's supposed to be. When this menu is scrolled beyond the number of valid entries, the game will attempt to dereference a NULL `text` pointer, which causes the crash.

The reason this bug only occurs in the 64-bit build is because of the difference in pointer width. in `menudata_training` struct, there is a member called `struct mpconfigfull *mpconfig`. This member is 8 bytes wide in the 64-bit build but only 4 bytes wide in the 32-bit build. Because of this, when `g_Menus[g_MpPlayerNum].training.weaponnum` is modified, it will instead clobber a different member of `g_Menus[g_MpPlayerNum].mpsetup`, `unke2c`, which has no side-effect.

Modifying union members can be risky and easily result in bugs such as this one. It is safer and easier to store the data in a unique struct, or simply not inside an existing union, to ensure that your additions won't end up accidentally clobbering other members or vice-versa. Modifying existing data/structs that are not part of a union should be safe. Anyway, I removed `unke28` and `unke2c` from `mpsetup` struct. The way they were named suggested that they were part of the original decomp, but they were actually, I guess, added as padding to fix some issues of modifying that union member. `showpresets` has been relocated to a new `mpsetupext` struct, which is where additional multiplayer setup menu data should go in the future.