### PR TITLE
Preserve Combat Simulator sim list after Co-Op/Counter-Op

### DIFF
--- a/port/src/pdmain.c
+++ b/port/src/pdmain.c
@@ -462,6 +462,9 @@ void mainLoop(void)
 		}
 
 		if (g_Vars.coopplayernum >= 0 || g_Vars.antiplayernum >= 0) {
+			if (g_MpSetup.chrslots & 0xfff0) {
+				g_MpSetup.storedbotbits = g_MpSetup.chrslots & 0xfff0;
+			}
 			g_MpSetup.chrslots = 0x03;
 			mpReset();
 		} else if (g_Vars.perfectbuddynum) {

--- a/src/game/menutick.c
+++ b/src/game/menutick.c
@@ -286,6 +286,12 @@ void menuTick(void)
 
 		if (g_MenuData.root == MENUROOT_MPSETUP || g_MenuData.root == MENUROOT_4MBMAINMENU) {
 			if (g_MenuData.prevmenuroot == -1) {
+#ifndef PLATFORM_N64
+				if (g_MpSetup.storedbotbits) {
+					g_MpSetup.chrslots |= g_MpSetup.storedbotbits;
+					g_MpSetup.storedbotbits = 0;
+				}
+#endif
 				g_MpSetup.chrslots &= 0xfff0;
 			}
 

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -4107,6 +4107,11 @@ struct mpsetup {
 	/*0x800acba0*/ u8 weapons[NUM_MPWEAPONSLOTS];
 	/*0x800acba6*/ u8 paused;
 	/*0x800acba8*/ struct fileguid fileguid;
+#ifndef PLATFORM_N64
+	// Used to restore the non-player bits of chrslots upon entering Combat
+	// Simulator, after playing Co-Op/Counter-Op with a human sim.
+	u16 storedbotbits;
+#endif
 };
 
 struct bossfile {


### PR DESCRIPTION
Mentioned in #673 as a bug, but it turned out to actually be a feature. This diverges from N64 behavior, but I consider it to be more practical, especially considering that the CS sim list was already preserved if the Co-Op sim is a non-human player. There didn't appear to be any issues while testing this change.