### PR TITLE
fix homeDir check

### DIFF
--- a/port/src/fs.c
+++ b/port/src/fs.c
@@ -114,7 +114,7 @@ s32 fsInit(void)
 		if (!portable) {
 			if (fsFileSize("./" DEFAULT_BASEDIR_NAME) >= 0) {
 				path = "./" DEFAULT_BASEDIR_NAME;
-			} else if (fsFileSize("$H/" DEFAULT_BASEDIR_NAME)) {
+			} else if (fsFileSize("$H/" DEFAULT_BASEDIR_NAME) >= 0) {
 				path = "$H/" DEFAULT_BASEDIR_NAME;
 			}
 		}


### PR DESCRIPTION
Fixes: https://github.com/fgsfdsfgs/perfect_dark/issues/664

On linux, stat.st_size returns 0 for directories on bcachefs