### PR TITLE
default PC's KB/M Menu bindings navigation now reflects newer PC Games' KB/M setup

### DIFF
--- a/port/src/input.c
+++ b/port/src/input.c
@@ -195,7 +195,7 @@ void inputSetDefaultKeyBinds(s32 cidx, s32 n64mode)
 		{ CK_RTRIG,         VK_MOUSE_RIGHT,      SDL_SCANCODE_Z      },
 		{ CK_LTRIG,         SDL_SCANCODE_F,      SDL_SCANCODE_X      },
 		{ CK_ZTRIG,         VK_MOUSE_LEFT,       SDL_SCANCODE_SPACE  },
-		{ CK_START,         SDL_SCANCODE_RETURN, SDL_SCANCODE_TAB    },
+		{ CK_START,         SDL_SCANCODE_TAB,    0                   },
 		{ CK_DPAD_D,        SDL_SCANCODE_Q,      VK_MOUSE_MIDDLE     },
 		{ CK_DPAD_U,        0,                   0                   },
 		{ CK_Y,             VK_MOUSE_WHEEL_DN,   0                   },
@@ -209,7 +209,9 @@ void inputSetDefaultKeyBinds(s32 cidx, s32 n64mode)
 		{ CK_STICK_YNEG,    SDL_SCANCODE_DOWN,   0                   },
 		{ CK_STICK_YPOS,    SDL_SCANCODE_UP,     0                   },
 		{ CK_4000,          SDL_SCANCODE_LSHIFT, 0                   },
-		{ CK_2000,          SDL_SCANCODE_LCTRL,  0                   }
+		{ CK_2000,          SDL_SCANCODE_LCTRL,  0                   },
+		{ CK_ACCEPT,        SDL_SCANCODE_RETURN, SDL_SCANCODE_E      },
+		{ CK_CANCEL,        VK_MOUSE_RIGHT,      0                   },
 	};
 
 	static const u32 pcjoybinds[][2] = {


### PR DESCRIPTION
Those who are playing the PC Port of Perfect Dark for the first time, but are used to newer PC games' menu bindings will find out Menu bindings don't confined towards a modern standard. 

now: The **RETURN/ENTER** key will become a proper Confirm action, as opposed to emulating as a START button. This addresses a muscle memory issue with how the **ENTER** key forcefully exits out of the menu as opposed to confirm, but the emulated START button will still be **TAB** key. The Right Mouse Click now behaves as a Cancel action.

This won't affect existing Perfect Dark PC Players' bindings. but the next time you reset [Key Bindings] menu, you will experience a more streamlined and KB/M-friendly navigation experience.