### PR TITLE
Improve scissor operations to correct "thin blue line" bug

### DIFF
--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -1641,11 +1641,18 @@ static void gfx_sp_extra_geometry_mode(uint32_t clear, uint32_t set) {
 
 static void gfx_adjust_viewport_or_scissor(XYWidthHeight* area, bool preserve_aspect = false) {
     // HACK: assume all target framebuffers have the same aspect
-    area->width *= RATIO_X;
-    area->x *= RATIO_X;
-    area->height *= RATIO_Y;
-    area->y = SCREEN_HEIGHT - area->y;
-    area->y *= RATIO_Y;
+    // Use floor/ceil to ensure scissor fully contains the logical region
+    // and prevents sub-pixel gaps at viewport edges
+    float x1 = area->x * RATIO_X;
+    float y1 = (SCREEN_HEIGHT - area->y) * RATIO_Y;
+    float x2 = (area->x + area->width) * RATIO_X;
+    float y2 = (SCREEN_HEIGHT - area->y + area->height) * RATIO_Y;
+    
+    area->x = std::floor(x1);
+    area->y = std::floor(y1);
+    area->width = std::ceil(x2) - area->x;
+    area->height = std::ceil(y2) - area->y;
+    
     if (preserve_aspect) {
         // preserve native aspect ratio
         const float ratio = gfx_current_native_aspect / gfx_current_dimensions.aspect_ratio;


### PR DESCRIPTION
[Along the lines of these](https://github.com/fgsfdsfgs/perfect_dark/issues/267) [two (identical?) issues](https://github.com/fgsfdsfgs/perfect_dark/issues/494) I also [identified and closed this issue](https://github.com/TartanSpartan/perfect_dark/issues/7) on my fork. By using floats, floors and ceilings, we ensure that the scissor will fully contain the logical region and prevents sub-pixel gaps at viewport edges, fixing the issue.

It goes from this (note the thin line between the top black bar and the cutscene):

![Image](https://github.com/user-attachments/assets/e400b6e4-358c-4b0d-8ee8-4706e69f66e4)

to this:

<img width="2488" height="1522" alt="Screenshot from 2026-01-29 22-29-27" src="https://github.com/user-attachments/assets/a0e37f8e-c13e-4edd-9920-6ea6d45162f5" />

 This PR for your upstream version does not include any PS Vita-specific code.