### PR TITLE
Vertical Camera Angle wrapping fix

### DIFF
--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -2415,14 +2415,6 @@ void bmoveTick(bool allowc1x, bool allowc1y, bool allowc1buttons, bool ignorec2)
 
 void bmoveUpdateVerta(void)
 {
-	while (g_Vars.currentplayer->vv_verta < -180) {
-		g_Vars.currentplayer->vv_verta += 360;
-	}
-
-	while (g_Vars.currentplayer->vv_verta >= 180) {
-		g_Vars.currentplayer->vv_verta -= 360;
-	}
-
 	if (g_Vars.currentplayer->vv_verta > 90) {
 		g_Vars.currentplayer->vv_verta = 90;
 	} else if (g_Vars.currentplayer->vv_verta < -90) {


### PR DESCRIPTION
during the work on https://github.com/fgsfdsfgs/perfect_dark/pull/648, i accidentally discovered a solution to the Reset Camera function when using SteamInput's Reset Camera function, or any other Input Remapper that has a similar function.

for context: Steam Input has the ability to assign a Reset Camera (referred as "Reset to Horizon") to any game to mimick a similar functionality, assuming the Angle Calibration is already done in advance. Unfortunately, if a game decides to put a 90 degree clamp limit: then it will not work as intended.

here's the bug in action:

https://github.com/user-attachments/assets/0d96a410-a8e5-4f85-832f-c1c49dc41d3e

This PR attempts to remedy this situation by removing the clamp limit entirely.

https://github.com/user-attachments/assets/47b6ab54-eda9-4670-a647-52d316caa2d7

While the bug can still persist when in a specific vertical angle, it should be lessen. This should at least have Input Remapper-based Reset Camera function to play nicely within the confines of the Mouse Input. 
For Steam Input players: This will serve as a substitute until https://github.com/fgsfdsfgs/perfect_dark/pull/682 gets added in.