### PR TITLE
Acknowledge npc gifts and suppress spurious cutscene notifications

### DIFF
--- a/src/game/chraicommands.c
+++ b/src/game/chraicommands.c
@@ -2330,7 +2330,7 @@ bool aiGiveObjectToChr(void)
 			}
 #endif
 
-			something = propPickupByPlayer(obj->prop, 0);
+			something = propPickupByPlayer(obj->prop, 1);
 			propExecuteTickOperation(obj->prop, something);
 			playernum = playermgrGetPlayerNumByProp(chr->prop);
 			obj2->hidden = (playernum << 28) | (obj2->hidden & 0x0fffffff);

--- a/src/game/propobj.c
+++ b/src/game/propobj.c
@@ -17201,6 +17201,12 @@ void currentPlayerQueuePickupWeaponHudmsg(u32 weaponnum, bool dual)
 {
 	char buffer[100] = "";
 
+	// Suppress pickup HUD during cutscenes
+	if (g_Vars.in_cutscene)
+	{
+		return;
+	}
+
 	weaponGetPickupText(buffer, weaponnum, dual);
 	hudmsgCreateWithFlags(buffer, HUDMSGTYPE_DEFAULT, HUDMSGFLAG_ONLYIFALIVE | HUDMSGFLAG_ALLOWDUPES);
 }
@@ -17215,6 +17221,13 @@ s32 propPickupByPlayer(struct prop *prop, bool showhudmsg)
 
 	if (g_Vars.currentplayer->isdead || g_Vars.lvupdate240 == 0) {
 		return TICKOP_NONE;
+	}
+
+	// Suppress HUD pickup messages during cutscenes (e.g. items given at
+	// mission start via aiGiveObjectToChr)
+	if (g_Vars.in_cutscene)
+	{
+		showhudmsg = false;
 	}
 
 	switch (obj->type) {


### PR DESCRIPTION
[This one](https://github.com/TartanSpartan/perfect_dark/commit/55ca51d8cc99b5855ca7233d77d0a84bd81516a0) successfully causes Elvis's proximity mine gift in Crash Site to be acknowledged in the HUD (along with similar notifications which may have been absent before but can't think of any off the top of my head, doesn't mean they aren't there though), but regressed in that it also caused mission opening cutscenes to report new, useless "Picked up a [gadget]" HUD notifications (for gadgets already in your inventory as a mission loadout) which isn't desirable behaviour. So, [another commit](https://github.com/TartanSpartan/perfect_dark/commit/cc3886888a187c83618c0cad28431976de01ee91) explicitly suppresses such notifications so as to undo the regression.

![2026-01-30-084409](https://github.com/user-attachments/assets/fad0810e-72cf-400a-aa03-c4ee206385a3)

Neither of these commits contain PS Vita-specific code. [Addresses this issue](https://github.com/fgsfdsfgs/perfect_dark/issues/699).