### PR TITLE
Fix issue for some cheats across build optimizations

### DIFF
--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -309,7 +309,7 @@ MenuItemHandlerResult cheatCheckboxMenuHandler(s32 operation, struct menuitem *i
 			return false;
 		}
 
-		if (g_CheatsEnabledBank1 & (1 << item->param)) {
+		if (g_CheatsEnabledBank1 & (1 << (item->param - 32))) {
 			return true;
 		}
 
@@ -334,11 +334,12 @@ MenuItemHandlerResult cheatCheckboxMenuHandler(s32 operation, struct menuitem *i
 				}
 			} else {
 				// Bank 1
-				if (g_CheatsEnabledBank1 & (1 << item->param)) {
+				if (g_CheatsEnabledBank1 & (1 << (item->param - 32))) {
+				// We need to subtract 32 on lines like these to avoid undefined behavior, namely ensuring that all cheats are toggled correctly and regardless of build optimiaztion
 					if (1);
-					g_CheatsEnabledBank1 = g_CheatsEnabledBank1 & ~(1 << item->param);
+					g_CheatsEnabledBank1 = g_CheatsEnabledBank1 & ~(1 << (item->param - 32));
 				} else {
-					g_CheatsEnabledBank1 = g_CheatsEnabledBank1 | 1 << item->param;
+					g_CheatsEnabledBank1 = g_CheatsEnabledBank1 | (1 << (item->param - 32));
 				}
 			}
 		}


### PR DESCRIPTION
[This change](https://github.com/TartanSpartan/perfect_dark/commit/426f9c68902d0a65a6d89cc43efc90ab61eb84a0) helps the bitmask for the cheats to be properly enabled regardless of build optimization settings. Before this fix, x86 hardware masked the shift count to 5 bits for 32-bit operands in the case of -Og, accidentally producing the correct bitmask and mimicking the masked shift which N64 hardware also implemented (seemingly a lucky accident or a quick fix hack back then). 

This fix ensures the correct bitmask and avoids a no-op for the codepath even under the aggressive optimization of -O2 and above. Tested and verified for builds under -O0 through -O3; the [previously-faulty cheats](https://github.com/fgsfdsfgs/perfect_dark/issues/528) can be toggled in all cases.

[So you may wish to change the block](https://github.com/fgsfdsfgs/perfect_dark/blob/246d737663c3eae4c1cfdc0cb32f92b3fd353d8a/CMakeLists.txt) starting from this comment:

"# Set Release optimization to -Og until I fix the -O2 issues"

but I can't vouch for whether this fix to toggle cheats is the only thing you wanted to get working so as to action that change in CMakeLists.txt, your call.