### PR TITLE
Fix a regression in light artifact handling through character models

### DIFF
--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -1071,7 +1071,7 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 				objTestHit(prop, &shotdata);
 			}
 			if (shotdata.hits[0].prop) {
-				texturenum = shotdata.hits[0].hitthing.texturenum;
+				texturenum = (prop->type == PROPTYPE_CHR || prop->type == PROPTYPE_PLAYER) ? -1 : shotdata.hits[0].hitthing.texturenum;
 				surfacetype = (texturenum >= 0 && texturenum < NUM_TEXTURES) ? g_Textures[texturenum].surfacetype : SURFACETYPE_DEFAULT;
 				// ignore some glass parts and shields
 				if (shotdata.hits[0].slowsbullet && texturenum != 10000 &&


### PR DESCRIPTION
This PR addresses an intermittent issue with light artifact handling through character models. The issue is an unintended consequence of my earlier PR merge at e1dd49fc3a4daed4588203de227e85c99876b89f that excluded glass surfaces from the line-of-sight test.

My sincere apologies for causing this!

The Issue
========
The surface check relies `texturenum` returned from shotdata. However, I didn't realize that `texturenem` is not initialized by the cheap version of chrTestHit when testing line-of-sight through character models. It therefore returns a random number (potentially filled by other parts of the line-of-sight calculation) that occasionally allows lights to shine through enemy characters like the example below from the defection level:

<img width="300" alt="Screenshot_20260312_180106" src="https://github.com/user-attachments/assets/0a58039d-f8f7-4eb0-b7e7-5ad02311de8a" />

In principle, this issue was also present with earlier logic that checked `(shotdata.hits[0].slowsbullet && texturenum != 10000)` but it triggered much less frequently.

Solution from this PR
==================
This PR addresses the issue by setting texturenum to -1 in cases where `prop->type` is a character or player model. This is the value that is returned by the expensive version of chrTestHit. The expensive version makes sure to initialize texturenum to -1 within bgTestHitOnChr.

Sorry again for making this bug worse with my earlier PR.