### PR TITLE
Fix for light visibility through shields

### DIFF
--- a/src/game/chr.c
+++ b/src/game/chr.c
@@ -4544,7 +4544,10 @@ void chrTestHit(struct prop *prop, struct shotdata *shotdata, bool isshooting, b
 
 			if (hitpart) {
 				if (chrGetShield(chr) > 0.0f) {
-					var8005efc0 = 10.0f / model->scale;
+#ifndef PLATFORM_N64
+					if (g_BgHitXluDisabled == false)
+#endif
+						var8005efc0 = 10.0f / model->scale;
 				}
 
 				child = prop->child;

--- a/src/game/chr.c
+++ b/src/game/chr.c
@@ -4545,6 +4545,13 @@ void chrTestHit(struct prop *prop, struct shotdata *shotdata, bool isshooting, b
 			if (hitpart) {
 				if (chrGetShield(chr) > 0.0f) {
 #ifndef PLATFORM_N64
+					/**
+					 * var8005efc0 > 0.0f adds a padding to bbox hit detection
+					 * in modelTestBboxNodeForHit() that accounts for a character's
+					 * surrounding shield. We skip this step on PC when checking
+					 * line-of-sight hits to light artifacts because lights should
+					 * be visible through the transparent shield.
+					 */
 					if (g_BgHitXluDisabled == false)
 #endif
 						var8005efc0 = 10.0f / model->scale;

--- a/src/include/bss.h
+++ b/src/include/bss.h
@@ -295,6 +295,7 @@ extern s32 g_JpnMaxCacheItems;
 extern s32 var8009d370jf;
 #ifndef PLATFORM_N64
 extern bool g_ValidGbcRomFound;
+extern bool g_BgHitXluDisabled;
 #endif
 
 #endif


### PR DESCRIPTION
Issue
====
On PC the line-of-sight calculation for light artifacts currently triggers on the transparency effect surrounding shielded characters.  This turns off lights that are visible through shields in the N64 version.

An easy place to see this is the light behind the shoulder of the second enemy in the defection level when using the Enemy Shields cheat.

<img width="300" alt="port" src="https://github.com/user-attachments/assets/99229a8e-0eaa-47cd-baf4-815af028ce13" />

This light is visible with ParaLLEl N64 emulation (a proxy for original hardware behavior)

<img width="300" alt="ParaLLEl N64" src="https://github.com/user-attachments/assets/138436f8-d7d5-42ce-b514-46ab10a2b411" />

Cause
=====
This is due to the shield padding being added as the global variable `var8005efc0` in the cheap version of chrTestHit()

[src/game/chr.c](https://github.com/fgsfdsfgs/perfect_dark/blob/port/src/game/chr.c)
```
4516 void chrTestHit(struct prop *prop, struct shotdata *shotdata, bool isshooting, bool cheap)
...
4546				if (chrGetShield(chr) > 0.0f) {
4547					var8005efc0 = 10.0f / model->scale;
4548				}
```
which increases bbox values inside modelTestBboxNodeForHit()

[src/lib/model.c](https://github.com/fgsfdsfgs/perfect_dark/blob/port/src/lib/model.c)
```
3575 bool modelTestBboxNodeForHit(struct modelrodata_bbox *bbox, Mtxf *mtx, struct coord *arg2, struct coord *arg3)
...
3622	if (var8005efc0 != 0.0f) {
3623		xmin -= var8005efc0;
3624		xmax += var8005efc0;
3625		ymin -= var8005efc0;
3626		ymax += var8005efc0;
3627		zmin -= var8005efc0;
3628		zmax += var8005efc0;
3629	}
```

This PR
======
This PR fixes this behavior by re-using `g_BgHitXluDisabled` to disable the shield padding during the light artifact calculation loop. It's fairly straightforward since we already disable hits on transparent background geometry during the artifact loop using this global. 

This allows lights to be visible through shield transparencies:

<img width="300" alt="this PR" src="https://github.com/user-attachments/assets/15be9c97-2806-421d-b9ff-52b24177617e" />


