### PR TITLE
Fix SIGBUS on ARM 32bit when starting level 3

### DIFF
--- a/port/src/preprocess/filepads.c
+++ b/port/src/preprocess/filepads.c
@@ -266,6 +266,12 @@ static u32 convertPadsFile(u8 *dst, u8 *src)
 	host_header->ptr_waygroups = (dstpos);
 	dstpos = convertWayGroups(dst, dstpos, src, PD_BE32(n64_header->ptr_waygroups));
 
+    // On 32bit ARM the covers MUST be 32bit aligned for float access, otherwise SIGBUS
+    // This fixes crash when starting level 3
+#if PLATFORM_ARM == 7
+    dstpos = (dstpos + 3) & ~3u;
+#endif
+
 	// Cover
 	host_header->ptr_cover = (dstpos);
 	dstpos = convertCover(dst, dstpos, src, PD_BE32(n64_header->ptr_cover), num_covers);


### PR DESCRIPTION
Fix float misalignment when on ARM7, this was causing SIGBUS sig when starting level 3. Could be other instances of this but it let me start level 3.