### PR TITLE
Reset hit prop to continue los test following a glass surface

### DIFF
--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -1078,6 +1078,7 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 				    surfacetype != SURFACETYPE_GLASS && surfacetype != SURFACETYPE_GLASSXLU) {
 					return false;
 				}
+				shotdata.hits[0].prop = NULL;
 			}
 		}
 		propptr--;


### PR DESCRIPTION
This PR fixes an edge case where light artifacts through glass doors become disabled if the door is followed by a character in the prop list. 

Cause
=====
We continue the hit test loop after glass objects without resetting the hit prop. This means a glass door will set the hit and continue the loop to the next character prop. The character will then flip texturenum to a non-glass surface since we force SURFACETYPE_DEFAULT given that the cheap version of chrTestHit doesn't assign a texturenum value. This will mistakenly register as a hit.

The issue can be seen on the floor below Cassandra's office in the Defection level. The lights will be disabled by the elevator door when it's followed by character models in the prop loop.

<img height="160" alt="visiblelos_pc_port" src="https://github.com/user-attachments/assets/d6213d7a-9194-40cb-ba36-17f13a4909ce" />

Solution
=======
Setting hit prop back to NULL prevents the next prop from triggering the line-of-sight test using prior information from a transparent prop.

<img height="160" alt="visiblelos_this_pr" src="https://github.com/user-attachments/assets/984556ed-cf73-4a92-8a5b-2542c2003c89" />


