### PR TITLE
Allow player character to block lights in camspy mode

### DIFF
--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -1064,7 +1064,8 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 		prop = *propptr;
 		if (prop) {
 			if (prop->type == PROPTYPE_CHR
-					|| (prop->type == PROPTYPE_PLAYER && prop->chr && (g_Vars.in_cutscene || playermgrGetPlayerNumByProp(prop) != g_Vars.currentplayernum))) {
+					|| (prop->type == PROPTYPE_PLAYER && prop->chr && (g_Vars.in_cutscene || playermgrGetPlayerNumByProp(prop) != g_Vars.currentplayernum
+							|| g_Vars.currentplayer->eyespy->mode == EYESPYMODE_CAMSPY))) {
 				chrTestHit(prop, &shotdata, false, true);
 			} else if (prop->type == PROPTYPE_WEAPON || (prop->type == PROPTYPE_DOOR && ((struct doorobj *)prop->obj)->doortype != DOORTYPE_LASER)
 					|| (prop->type == PROPTYPE_OBJ && prop->obj->type != OBJTYPE_GLASS && prop->obj->type != OBJTYPE_TINTEDGLASS)) {


### PR DESCRIPTION
This change allows the player's character model to block lights when in CamSpy mode to match the behavior on N64.

Comparison between current PC port, this PR, and ParaLLEl N64 (a proxy for original hardware):

<img height="160" alt="camspy_port" src="https://github.com/user-attachments/assets/27af0561-5e59-443c-ab46-5fe88d15bad2" /> <img height="160" alt="camspy_this_pr" src="https://github.com/user-attachments/assets/98a0cb59-19ff-4b37-8a28-a7a8c93629f0" /> <img height="160" alt="camspy_parallel" src="https://github.com/user-attachments/assets/d3273978-430c-4ea6-9cec-5e7f977276f8" />



