### PR TITLE
Allow player character to block lights in camspy mode

### DIFF
--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -1064,7 +1064,8 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 		prop = *propptr;
 		if (prop) {
 			if (prop->type == PROPTYPE_CHR
-					|| (prop->type == PROPTYPE_PLAYER && prop->chr && (g_Vars.in_cutscene || playermgrGetPlayerNumByProp(prop) != g_Vars.currentplayernum))) {
+					|| (prop->type == PROPTYPE_PLAYER && prop->chr && (g_Vars.in_cutscene || playermgrGetPlayerNumByProp(prop) != g_Vars.currentplayernum
+							|| g_Vars.currentplayer->eyespy->mode == EYESPYMODE_CAMSPY))) {
 				chrTestHit(prop, &shotdata, false, true);
 			} else if (prop->type == PROPTYPE_WEAPON || (prop->type == PROPTYPE_DOOR && ((struct doorobj *)prop->obj)->doortype != DOORTYPE_LASER)
 					|| (prop->type == PROPTYPE_OBJ && prop->obj->type != OBJTYPE_GLASS && prop->obj->type != OBJTYPE_TINTEDGLASS)) {

--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -1065,7 +1065,7 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 		if (prop) {
 			if (prop->type == PROPTYPE_CHR
 					|| (prop->type == PROPTYPE_PLAYER && prop->chr && (g_Vars.in_cutscene || playermgrGetPlayerNumByProp(prop) != g_Vars.currentplayernum
-							|| g_Vars.currentplayer->eyespy->mode == EYESPYMODE_CAMSPY))) {
+						|| g_Vars.currentplayer->eyespy && g_Vars.currentplayer->eyespy->mode == EYESPYMODE_CAMSPY))) {
 				chrTestHit(prop, &shotdata, false, true);
 			} else if (prop->type == PROPTYPE_WEAPON || (prop->type == PROPTYPE_DOOR && ((struct doorobj *)prop->obj)->doortype != DOORTYPE_LASER)
 					|| (prop->type == PROPTYPE_OBJ && prop->obj->type != OBJTYPE_GLASS && prop->obj->type != OBJTYPE_TINTEDGLASS)) {


### PR DESCRIPTION
This change allows the player's character model to block lights when in CamSpy mode to match the behavior on N64. It tests whether the eyespy struct is present (to avoid a segfault during cutscene transitions) and active.

Comparison between current PC port, this PR, and ParaLLEl N64 (a proxy for original hardware):

<img height="160" alt="camspy_port" src="https://github.com/user-attachments/assets/ea04dc5a-7302-4fc3-960f-3b6e6ee52a73" /> <img height="160" alt="camspy_this_pr" src="https://github.com/user-attachments/assets/bcd3e27e-4305-4d6b-928f-4ccd3f851f5b" /> <img  height="160" alt="camspy_parallel" src="https://github.com/user-attachments/assets/75ca7832-95f7-4e88-9b88-2bfae0511e71" />
