### PR TITLE
Added 2 launch options: --skip-jo-on-pc --combat-simulator

### DIFF
--- a/port/src/main.c
+++ b/port/src/main.c
@@ -39,6 +39,8 @@ s32 g_TickRateDiv = 1;
 s32 g_TickExtraSleep = true;
 
 s32 g_SkipIntro = false;
+s32 g_SkipToCombatSimulator = false;
+s32 g_SkipJoOnPc = false;
 
 s32 g_FileAutoSelect = -1;
 
@@ -133,6 +135,9 @@ int main(int argc, const char **argv)
 	sysLogPrintf(LOG_NOTE, "rom  file at %p - %p", g_RomFile, g_RomFile + g_RomFileSize);
 
 	g_SndDisabled = sysArgCheck("--no-sound");
+
+	g_SkipToCombatSimulator = sysArgCheck("--combat-simulator");
+	g_SkipJoOnPc = g_SkipToCombatSimulator || sysArgCheck("--skip-jo-on-pc");
 
 	g_StageNum = sysArgGetInt("--boot-stage", STAGE_TITLE);
 

--- a/src/game/chraicommands.c
+++ b/src/game/chraicommands.c
@@ -4908,7 +4908,11 @@ bool aiIfCutsceneButtonPressed(void)
 	u8 *cmd = g_Vars.ailist + g_Vars.aioffset;
 
 	if ((g_Vars.in_cutscene && g_CutsceneSkipRequested) ||
+#ifndef PLATFORM_N64
+			(g_Vars.stagenum == STAGE_CITRAINING && (var80087260 > 0 || g_SkipJoOnPc))) {
+#else
 			(g_Vars.stagenum == STAGE_CITRAINING && var80087260 > 0)) {
+#endif
 		g_Vars.aioffset = chraiGoToLabel(g_Vars.ailist, g_Vars.aioffset, cmd[2]);
 	} else {
 		g_Vars.aioffset += 3;

--- a/src/game/mainmenu.c
+++ b/src/game/mainmenu.c
@@ -4867,6 +4867,12 @@ MenuDialogHandlerResult menudialogMainMenu(s32 operation, struct menudialogdef *
 		g_Menus[g_MpPlayerNum].main.unke2c = 0;
 		break;
 	case MENUOP_TICK:
+#ifndef PLATFORM_N64
+		if (g_SkipToCombatSimulator) {
+			menuhandlerMainMenuCombatSimulator(MENUOP_SET, NULL, NULL);
+			break;
+		}
+#endif
 		if (g_Menus[g_MpPlayerNum].curdialog &&
 				g_Menus[g_MpPlayerNum].curdialog->definition == dialogdef) {
 			g_MissionConfig.iscoop = false;

--- a/src/game/menutick.c
+++ b/src/game/menutick.c
@@ -268,7 +268,13 @@ void menuTick(void)
 	if (g_FileState == FILESTATE_UNSELECTED && g_Vars.stagenum == STAGE_CITRAINING) {
 		g_PlayersWithControl[0] = false;
 
+#ifndef PLATFORM_N64
+		if ((g_Vars.lvframenum > 30 && g_Vars.tickmode != TICKMODE_CUTSCENE) ||
+			(g_SkipJoOnPc && g_Vars.lvframenum >= 7)) {
+			g_SkipJoOnPc = false;
+#else
 		if (g_Vars.lvframenum > 30 && g_Vars.tickmode != TICKMODE_CUTSCENE) {
+#endif
 			g_Menus[0].openinhibit = 0;
 			g_Menus[1].openinhibit = 0;
 			g_Menus[2].openinhibit = 0;
@@ -581,7 +587,13 @@ void menuTick(void)
 
 				if (g_MenuData.root == MENUROOT_MPSETUP || g_MenuData.root == MENUROOT_4MBMAINMENU) {
 					startmusic = true;
+#ifndef PLATFORM_N64
+					if (!g_SkipToCombatSimulator) {
+#endif
 					sndStart(var80095200, SFX_EXPLOSION_8098, 0, -1, -1, -1, -1, -1);
+#ifndef PLATFORM_N64
+					}
+#endif
 				}
 
 				if (g_MenuData.root == MENUROOT_MAINMENU || g_MenuData.root == MENUROOT_TRAINING) {
@@ -593,6 +605,10 @@ void menuTick(void)
 								|| g_Vars.currentplayer->prop->rooms[0] == 0x1e
 								|| (dtdata && dtdata->intraining))) {
 						startmusic = false;
+#ifndef PLATFORM_N64
+					} else if (g_SkipToCombatSimulator) {
+						startmusic = false;
+#endif
 					} else {
 						startmusic = true;
 					}

--- a/src/game/mplayer/setup.c
+++ b/src/game/mplayer/setup.c
@@ -5395,6 +5395,12 @@ MenuDialogHandlerResult menudialogCombatSimulator(s32 operation, struct menudial
 		g_Vars.waitingtojoin[2] = false;
 		g_Vars.waitingtojoin[3] = false;
 	}
+#ifndef PLATFORM_N64
+	else if (g_SkipToCombatSimulator) {
+		g_SkipToCombatSimulator = false;
+		menuhandlerMpAdvancedSetup(MENUOP_SET, NULL, NULL);
+	}
+#endif
 
 	if (g_Menus[g_MpPlayerNum].curdialog
 			&& g_Menus[g_MpPlayerNum].curdialog->definition == &g_CombatSimulatorMenuDialog

--- a/src/include/data.h
+++ b/src/include/data.h
@@ -558,6 +558,8 @@ extern s32 g_TickExtraSleep;
 extern s32 g_MusicDisableMpDeath;
 extern s32 g_BgunGeMuzzleFlashes;
 extern s32 g_FileAutoSelect;
+extern s32 g_SkipToCombatSimulator;
+extern s32 g_SkipJoOnPc;
 
 extern u8 g_MpWeaponSetRandomFilters[NUM_MPWEAPONS];
 extern s32 g_MpWeaponRandomFilterNum;


### PR DESCRIPTION
--skip-jo-on-pc: skip the little cutscene of Jo on the PC
--combat-simulator: skip the main menu into Combat Simulator > Advanced

--combat-simulator also skips Jo on the PC, so no need to use both. Use alongside --skip-intro and --profile 0 for maximum skippage.