### PR TITLE
Added cheat: Max LapTop turrent up to 16 at once for each player

### DIFF
--- a/src/game/cheats.c
+++ b/src/game/cheats.c
@@ -19,6 +19,7 @@ u32 g_CheatsActiveBank0;
 u32 g_CheatsActiveBank1;
 u32 g_CheatsEnabledBank0;
 u32 g_CheatsEnabledBank1;
+s32 g_LaptopTurretLimit = 1;
 
 struct menuitem g_CheatsBuddiesMenuItems[];
 struct menudialogdef g_CheatsBuddiesMenuDialog;
@@ -252,6 +253,7 @@ void cheatsInit(void)
 	g_CheatsActiveBank1 = 0;
 	g_CheatsEnabledBank0 = 0;
 	g_CheatsEnabledBank1 = 0;
+	g_LaptopTurretLimit = 1;
 }
 
 /**
@@ -294,6 +296,7 @@ void cheatsReset(void)
 	} else {
 		g_CheatsActiveBank0 = 0;
 		g_CheatsActiveBank1 = 0;
+		g_LaptopTurretLimit = 1;
 	}
 
 	// Set any "always on" cheats to active and properly activate all active cheats
@@ -420,6 +423,34 @@ char *cheatGetNameIfUnlocked(struct menuitem *item)
 	}
 
 	return langGet(L_MPWEAPONS_074); // "----------"
+}
+
+/**
+ * Slider handler for the number of laptop sentry guns the player may deploy at once.
+ * Value is stored in g_LaptopTurretLimit (read by laptopDeploy).
+ * Default 1 restores original single-turret behavior.
+ */
+MenuItemHandlerResult cheatMenuHandleLaptopTurretLimit(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+	switch (operation) {
+	case MENUOP_GETSLIDER:
+		data->slider.value = g_LaptopTurretLimit;
+		break;
+	case MENUOP_SET:
+		g_LaptopTurretLimit = data->slider.value;
+		if (g_LaptopTurretLimit < 1) {
+			g_LaptopTurretLimit = 1;
+		}
+		if (g_LaptopTurretLimit > 16) {
+			g_LaptopTurretLimit = 16;
+		}
+		break;
+	case MENUOP_GETSLIDERLABEL:
+		sprintf(data->slider.label, "%d\n", g_LaptopTurretLimit);
+		break;
+	}
+
+	return 0;
 }
 
 MenuDialogHandlerResult cheatMenuHandleDialog(s32 operation, struct menudialogdef *dialogdef, union handlerdata *data)
@@ -834,6 +865,7 @@ MenuItemHandlerResult cheatMenuHandleTurnOffAllCheats(s32 operation, struct menu
 	if (operation == MENUOP_SET) {
 		g_CheatsEnabledBank0 = 0;
 		g_CheatsEnabledBank1 = 0;
+		g_LaptopTurretLimit = 1;
 	}
 
 	return false;
@@ -1405,6 +1437,16 @@ struct menuitem g_CheatsWeaponsMenuItems[] = {
 		(uintptr_t)&cheatGetNameIfUnlocked,
 		0,
 		cheatCheckboxMenuHandler,
+	},
+	// Slider to control how many laptop sentry turrets the player can have active at once.
+	// Placed directly under the Unlimited Ammo - Laptop Sentry Gun option as requested.
+	{
+		MENUITEMTYPE_SLIDER,
+		0,
+		MENUITEMFLAG_SLIDER_ALTSIZE | MENUITEMFLAG_LITERAL_TEXT,
+		(uintptr_t)"Sentry Gun Limit",
+		16,
+		cheatMenuHandleLaptopTurretLimit,
 	},
 	{
 		MENUITEMTYPE_CHECKBOX,

--- a/src/game/propobj.c
+++ b/src/game/propobj.c
@@ -15365,9 +15365,10 @@ void objDamage(struct defaultobj *obj, f32 damage, struct coord *pos, s32 weapon
 {
 	// Store the attacker playernum into the object's "hidden" field
 #if VERSION >= VERSION_NTSC_1_0
-	// ...but not for deployed laptop guns in multiplayer, because those bits
-	// designate the owner of the gun
-	if (obj->type != OBJTYPE_AUTOGUN || !g_Vars.normmplayerisrunning) {
+	// ...but not for thrown laptop guns (they use the bits for owner),
+	// and not for other AUTOGUNs in multiplayer.
+	if ((obj->flags & OBJFLAG_THROWNLAPTOP) == 0 &&
+			(obj->type != OBJTYPE_AUTOGUN || !g_Vars.normmplayerisrunning)) {
 		obj->hidden &= 0x0fffffff;
 		obj->hidden |= (playernum << 28) & 0xf0000000;
 	}
@@ -16209,6 +16210,7 @@ bool propobjInteract(struct prop *prop)
 		if (obj->type == OBJTYPE_AUTOGUN) {
 			struct autogunobj *laptop = (struct autogunobj *)obj;
 			s32 playernum;
+			s32 laptopowner;
 
 			if (g_Vars.normmplayerisrunning) {
 				playernum = mpPlayerGetIndex(g_Vars.currentplayer->prop->chr);
@@ -16216,7 +16218,9 @@ bool propobjInteract(struct prop *prop)
 				playernum = g_Vars.currentplayernum;
 			}
 
-			if (playernum >= 0 && laptop == &g_ThrownLaptops[playernum]) {
+			laptopowner = (obj->hidden & 0xf0000000) >> 28;
+
+			if (playernum >= 0 && laptopowner == playernum) {
 				obj->hidden |= OBJHFLAG_DELETING;
 				invGiveSingleWeapon(WEAPON_LAPTOPGUN);
 				currentPlayerQueuePickupWeaponHudmsg(WEAPON_LAPTOPGUN, false);
@@ -18482,27 +18486,67 @@ struct autogunobj *laptopDeploy(s32 modelnum, struct gset *gset, struct chrdata 
 	struct prop *prop;
 	struct model *model;
 	struct autogunobj *laptop = NULL;
-	s32 index;
+	s32 i;
+	s32 index = -1;
+	s32 playernum;
+	s32 count;
+	s32 owner;
 
+	// Determine the owner playernum for quota counting (same logic as before)
 	if (g_Vars.normmplayerisrunning) {
-		index = mpPlayerGetIndex(chr);
+		playernum = mpPlayerGetIndex(chr);
 	} else {
-		index = playermgrGetPlayerNumByProp(chr->prop);
+		playernum = playermgrGetPlayerNumByProp(chr->prop);
 	}
 
-	if (index >= 0 && index < g_MaxThrownLaptops) {
+	// Enforce per-player concurrent limit from the cheat slider (default 1 for vanilla behavior).
+	// If the player already has g_LaptopTurretLimit active turrets, evict the first one we find
+	// (with explosion) so the new one can take a slot. This gives "N at once; N+1 replaces".
+	if (playernum >= 0 && g_ThrownLaptops) {
+		count = 0;
+		for (i = 0; i < g_MaxThrownLaptops; i++) {
+			if (g_ThrownLaptops[i].base.prop) {
+				owner = (g_ThrownLaptops[i].base.hidden & 0xf0000000) >> 28;
+				if (owner == playernum) {
+					count++;
+				}
+			}
+		}
+
+		if (count >= g_LaptopTurretLimit) {
+			for (i = 0; i < g_MaxThrownLaptops; i++) {
+				if (g_ThrownLaptops[i].base.prop) {
+					owner = (g_ThrownLaptops[i].base.hidden & 0xf0000000) >> 28;
+					if (owner == playernum) {
+#if VERSION >= VERSION_NTSC_1_0
+						explosionCreateSimple(NULL, &g_ThrownLaptops[i].base.prop->pos,
+								g_ThrownLaptops[i].base.prop->rooms, EXPLOSIONTYPE_LAPTOP, playernum);
+#else
+						explosionCreateSimple(NULL, &g_ThrownLaptops[i].base.prop->pos,
+								g_ThrownLaptops[i].base.prop->rooms, EXPLOSIONTYPE_LAPTOP, 0);
+#endif
+						objFreePermanently(&g_ThrownLaptops[i].base, true);
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	// Find a free slot in the pool
+	if (g_ThrownLaptops) {
+		for (i = 0; i < g_MaxThrownLaptops; i++) {
+			if (g_ThrownLaptops[i].base.prop == NULL) {
+				index = i;
+				break;
+			}
+		}
+	}
+
+	if (index >= 0) {
 		setupLoadModeldef(modelnum);
 		modeldef = g_ModelStates[modelnum].modeldef;
 		laptop = &g_ThrownLaptops[index];
-
-		if (laptop->base.prop) {
-#if VERSION >= VERSION_NTSC_1_0
-			explosionCreateSimple(NULL, &laptop->base.prop->pos, laptop->base.prop->rooms, EXPLOSIONTYPE_LAPTOP, index);
-#else
-			explosionCreateSimple(NULL, &laptop->base.prop->pos, laptop->base.prop->rooms, EXPLOSIONTYPE_LAPTOP, 0);
-#endif
-			objFreePermanently(&laptop->base, true);
-		}
 
 		prop = propAllocate();
 		model = modelmgrInstantiateModelWithoutAnim(modeldef);

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -297,13 +297,18 @@ void propsReset(void)
 	g_AutogunDamageRxScale = 1;
 	g_AmmoQuantityScale = 1;
 
-	g_MaxThrownLaptops = g_Vars.normmplayerisrunning ? 12 : PLAYERCOUNT();
+	// Large fixed pool for thrown laptop turrets (was per-player singleton).
+	// 16 is conservative for the early MEMPOOL_STAGE but still allows
+	// far more simultaneous turrets than the original limit of 1.
+	g_MaxThrownLaptops = 16;
 
 	g_ThrownLaptops = mempAlloc(ALIGN16(g_MaxThrownLaptops * sizeof(struct autogunobj)), MEMPOOL_STAGE);
 	g_ThrownLaptopBeams = mempAlloc(ALIGN16(g_MaxThrownLaptops * sizeof(struct beam)), MEMPOOL_STAGE);
 
-	for (i = 0; i < g_MaxThrownLaptops; i++) {
-		g_ThrownLaptops[i].base.prop = NULL;
+	if (g_ThrownLaptops) {
+		for (i = 0; i < g_MaxThrownLaptops; i++) {
+			g_ThrownLaptops[i].base.prop = NULL;
+		}
 	}
 }
 

--- a/src/game/training.c
+++ b/src/game/training.c
@@ -1284,8 +1284,13 @@ void frEndSession(bool hidetargets)
 			frHideAllTargets();
 		}
 
-		if (g_ThrownLaptops[0].base.prop) {
-			objFreePermanently(&g_ThrownLaptops[0].base, true);
+		// Free any active thrown laptops (pool may contain several after the multi-turret change)
+		if (g_ThrownLaptops) {
+			for (i = 0; i < g_MaxThrownLaptops; i++) {
+				if (g_ThrownLaptops[i].base.prop) {
+					objFreePermanently(&g_ThrownLaptops[i].base, true);
+				}
+			}
 		}
 
 		roomsCopy(g_Vars.currentplayer->prop->rooms, rooms);

--- a/src/include/bss.h
+++ b/src/include/bss.h
@@ -183,6 +183,7 @@ extern u32 g_CheatsActiveBank0;
 extern u32 g_CheatsActiveBank1;
 extern u32 g_CheatsEnabledBank0;
 extern u32 g_CheatsEnabledBank1;
+extern s32 g_LaptopTurretLimit;
 extern s32 g_FilemgrLastPakError;
 extern struct gamefile g_GameFile;
 extern struct fileguid g_GameFileGuid;

--- a/src/include/game/cheats.h
+++ b/src/include/game/cheats.h
@@ -29,4 +29,6 @@ MenuItemHandlerResult cheatCheckboxMenuHandler(s32 operation, struct menuitem *i
 MenuItemHandlerResult cheatMenuHandleBuddyCheckbox(s32 operation, struct menuitem *item, union handlerdata *data);
 MenuItemHandlerResult cheatMenuHandleTurnOffAllCheats(s32 operation, struct menuitem *item, union handlerdata *data);
 
+extern s32 g_LaptopTurretLimit;
+
 #endif


### PR DESCRIPTION
Original game only allow players to throw only one LapTop gun as sentry turrent.
With this patch was added an option on cheat menu to extend to max 16 turrets per player. 