### PR TITLE
Allow lights to pass through grated metal doors

### DIFF
--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -1078,7 +1078,7 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 			if (shotdata.hits[0].prop) {
 				texturenum = (prop->type == PROPTYPE_CHR || prop->type == PROPTYPE_PLAYER) ? -1 : shotdata.hits[0].hitthing.texturenum;
 				surfacetype = (texturenum >= 0 && texturenum < NUM_TEXTURES) ? g_Textures[texturenum].surfacetype : SURFACETYPE_DEFAULT;
-				grateddoor = (shotdata.hits[0].model->obj->modelnum == MODEL_DD_WINDDOOR) & (surfacetype == SURFACETYPE_DEFAULT);
+				grateddoor = (shotdata.hits[0].model->obj->modelnum == MODEL_DD_WINDDOOR) && (surfacetype == SURFACETYPE_DEFAULT);
 				// ignore some glass parts and shields
 				if (shotdata.hits[0].slowsbullet && texturenum != 10000 &&
 				    surfacetype != SURFACETYPE_GLASS && surfacetype != SURFACETYPE_GLASSXLU && !grateddoor) {

--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -994,6 +994,8 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 	struct prop *prop;
 	s16 texturenum;
 	u32 surfacetype;
+	s16 grateddoor;
+	f32 maxdistance;
 
 	shotdata.gunpos3d.x = gunpos3d->x;
 	shotdata.gunpos3d.y = gunpos3d->y;
@@ -1056,7 +1058,9 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 	delta.x = endpos3d->x - gunpos3d->x;
 	delta.y = endpos3d->y - gunpos3d->y;
 	delta.z = endpos3d->z - gunpos3d->z;
-	shotdata.distance = sqrtf(delta.x * delta.x + delta.y * delta.y + delta.z * delta.z);
+	maxdistance = sqrtf(delta.x * delta.x + delta.y * delta.y + delta.z * delta.z);
+
+	shotdata.distance = maxdistance;
 
 	// and check props
 	propptr = g_Vars.endonscreenprops - 1;
@@ -1074,12 +1078,14 @@ bool shotTestLos(struct coord *gunpos2d, struct coord *gundir2d, struct coord *g
 			if (shotdata.hits[0].prop) {
 				texturenum = (prop->type == PROPTYPE_CHR || prop->type == PROPTYPE_PLAYER) ? -1 : shotdata.hits[0].hitthing.texturenum;
 				surfacetype = (texturenum >= 0 && texturenum < NUM_TEXTURES) ? g_Textures[texturenum].surfacetype : SURFACETYPE_DEFAULT;
+				grateddoor = (shotdata.hits[0].model->obj->modelnum == MODEL_DD_WINDDOOR) & (surfacetype == SURFACETYPE_DEFAULT);
 				// ignore some glass parts and shields
 				if (shotdata.hits[0].slowsbullet && texturenum != 10000 &&
-				    surfacetype != SURFACETYPE_GLASS && surfacetype != SURFACETYPE_GLASSXLU) {
+				    surfacetype != SURFACETYPE_GLASS && surfacetype != SURFACETYPE_GLASSXLU && !grateddoor) {
 					return false;
 				}
 				shotdata.hits[0].prop = NULL;
+				shotdata.distance = maxdistance;
 			}
 		}
 		propptr--;


### PR DESCRIPTION
On N64, lights shine through the grated metal doors on the Defection level. This is because the central portion of the door is rendered as a transparency. This effect is shown below for the first door under the Defection helipad using PareLLEl N64 emulation as a proxy for original hardware:

<img height="150" alt="grated_door_parallel" src="https://github.com/user-attachments/assets/eca40e3b-f8f3-4196-80d9-64d7873afdd6" />

These lights are not currently visible behind this door type in the PC port because we only have exceptions for glass doors during the line-of-sight test for light artifacts:

<img height="150" alt="grated_door_pc_port" src="https://github.com/user-attachments/assets/d7467660-c72d-493f-bcd7-9b575dbcc60d" />

This PR attempts to fix this by excluding the transparent portion of this door model (MODEL_DD_WINDDOOR == 0x43) from the line-of-sight test. The transparent portion is identified by a surfacetype check since the transparency uses SURFACETYPE_DEFAULT whereas the metal door frame uses SURFACETYPE_MUD. I have no idea why the original devs chose mud for this door frame.

This is what the first door below the Defection helipad looks like using this PR:

<img height="150" alt="grated_door_this_pr" src="https://github.com/user-attachments/assets/c306c03b-01b3-4849-a213-67d49aea6f7a" />

And here is an example of the same door showing the metal frame partially obstructing a light when it's open:

<img height="150" alt="grated_door_this_pr2" src="https://github.com/user-attachments/assets/384b6ba0-7ba9-4a23-b0c7-68eb8da45790" />

This behavior seems to match the behavior on N64. The only levels that appear to use this door type are Defection, Extraction, and Mr. Blonde's Revenge (they all share the same basic layout).

Note
====
As part of this PR I added a variable `maxdistance` to reset the shotdistance when performing the line-of-sight test for lights. This is needed to handle pairs of grated doors where light can shine through the closer door in the prop loop. Without this change, the closer door will reduce the shotdistance when it runs objHitTest on the first door. The reduced distance excludes the farther door from the test unless we reset it to the original value in cases where we hit a transparent surface.

Here is an example of what happens if we don't reset the shotdistance with `maxdistance`. Lights that should be blocked by the second door can be visible through a closed door in front of the player.

<img height="150" alt="grated_door_disable_maxdistance_reset1" src="https://github.com/user-attachments/assets/bc72fddc-ca7f-4b17-b9a0-d21228f1a1b0" />
<img height="150" alt="grated_door_disable_maxdistance_reset2" src="https://github.com/user-attachments/assets/be5c14c6-c70d-4c25-b0c8-1b528ac1bae4" />

