### PR TITLE
Add opt-in FBO rendering for framebuffer effects without multisampling

### DIFF
--- a/port/fast3d/gfx_api.h
+++ b/port/fast3d/gfx_api.h
@@ -24,6 +24,7 @@ struct GfxInitSettings {
     struct GfxWindowManagerAPI *wapi;
     struct GfxRenderingAPI *rapi;
     struct GfxWindowInitSettings window_settings;
+    bool render_to_fbo;
 };
 
 extern struct GfxDimensions gfx_current_window_dimensions; // The dimensions of the window

--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -218,6 +218,7 @@ bool gfx_framebuffers_enabled = true;
 bool gfx_detail_textures_enabled = true;
 
 static bool game_renders_to_framebuffer;
+static bool render_to_fbo;
 static int game_framebuffer;
 static int game_framebuffer_msaa_resolved;
 
@@ -2549,6 +2550,7 @@ extern "C" void gfx_get_dimensions(uint32_t* width, uint32_t* height, int32_t* p
 extern "C" void gfx_init(const GfxInitSettings *settings) {
     gfx_wapi = settings->wapi;
     gfx_rapi = settings->rapi;
+    render_to_fbo = settings->render_to_fbo;
     gfx_wapi->init(&settings->window_settings);
     gfx_rapi->init();
     gfx_rapi->update_framebuffer_parameters(0, settings->window_settings.width, settings->window_settings.height, 1, false, true, true, true);
@@ -2631,7 +2633,7 @@ extern "C" void gfx_start_frame(void) {
 
     bool different_size = gfx_current_dimensions.width != gfx_current_game_window_viewport.width ||
                           gfx_current_dimensions.height != gfx_current_game_window_viewport.height;
-    if (gfx_framebuffers_enabled && (different_size || gfx_msaa_level > 1)) {
+    if (gfx_framebuffers_enabled && (different_size || gfx_msaa_level > 1 || render_to_fbo)) {
         game_renders_to_framebuffer = true;
         if (different_size) {
             gfx_rapi->update_framebuffer_parameters(game_framebuffer, gfx_current_dimensions.width,
@@ -2700,6 +2702,8 @@ extern "C" void gfx_run(Gfx* commands) {
             } else {
                 gfx_rapi->resolve_msaa_color_buffer(0, game_framebuffer);
             }
+        } else if (render_to_fbo) {
+            gfx_rapi->resolve_msaa_color_buffer(0, game_framebuffer);
         } else {
             gfxFramebuffer = (uintptr_t)gfx_rapi->get_framebuffer_texture_id(game_framebuffer);
         }
@@ -2787,7 +2791,7 @@ extern "C" void gfx_copy_framebuffer(int fb_dst, int fb_src, int left, int top, 
             // flip Y
             top = gfx_current_dimensions.height - top - 1;
         }
-        if (use_back && gfx_msaa_level > 1) {
+        if (use_back && game_renders_to_framebuffer && (gfx_msaa_level > 1 || render_to_fbo)) {
             // read from the framebuffer we've been rendering to
             fb_src = game_framebuffer;
         }

--- a/port/src/video.c
+++ b/port/src/video.c
@@ -40,6 +40,7 @@ static s32 vidCenter = false;
 static s32 vidAllowHiDpi = false;
 static s32 vidVsync = 1;
 static s32 vidMSAA = 1;
+static s32 vidRenderToFBO = 0;
 static s32 vidFramerateLimit = 0;
 
 static s32 vidDisplayFPS = 0;
@@ -95,7 +96,8 @@ s32 videoInit(void)
 			.maximized = vidMaximize,
 			.centered = vidCenter,
 			.allow_hidpi = vidAllowHiDpi
-		}
+		},
+		.render_to_fbo = (bool)vidRenderToFBO
 	};
 
 	gfx_init(&set);
@@ -574,6 +576,7 @@ PD_CONSTRUCTOR static void videoConfigInit(void)
 	configRegisterInt("Video.AllowHiDpi", &vidAllowHiDpi, 0, 1);
 	configRegisterInt("Video.VSync", &vidVsync, -1, 10);
 	configRegisterInt("Video.FramebufferEffects", &vidFramebuffers, 0, 1);
+	configRegisterInt("Video.RenderToFBO", &vidRenderToFBO, 0, 1);
 	configRegisterInt("Video.FramerateLimit", &vidFramerateLimit, 0, VIDEO_MAX_FPS);
 	configRegisterInt("Video.DisplayFPS", &vidDisplayFPS, 0, 1);
 	configRegisterFloat("Video.DisplayFPSInterval", &vidDisplayFPSInterval, 0.01f, 32.f);


### PR DESCRIPTION
## Summary

Adds an opt-in Video.RenderToFBO setting in pd.ini, disabled by default. No in-game menu option is added.

When enabled together with FramebufferEffects=1, the game uses its existing internal game framebuffer path even with MSAA=1. Framebuffer-copy operations used by those effects then read from the internal framebuffer instead of the default back buffer, and the completed frame is copied back to the default framebuffer before presentation.

Related to #570.



## Motivation

This started as more than a cosmetic issue on my Intel Ivy Bridge integrated GPU.

With antialiasing disabled (`MSAA=1`, meaning no multisampling), CamSpy rendered with black-screen and feedback-like distortion behaviour. CamSpy is an important gameplay device, so on the affected system it could not be used reliably when needed.

Cloak/invisibility effects also rendered incorrectly and could cause noticeable slowdown. Disabling framebuffer effects made the image usable again, but removed cloak, blur, and other effects that should remain available.

Setting `MSAA=2` fixed the problem because the renderer then used its existing internal game framebuffer path. However, multisampling was only being enabled as a workaround for the framebuffer-copy issue.

This change allows the existing internal FBO route to be used with `MSAA=1`, without enabling multisampling. It provides an opt-in compatibility setting in `pd.ini`, allowing affected systems to keep framebuffer effects without requiring `MSAA=2`.

This may also help users on similar older integrated GPUs or driver stacks where framebuffer effects fail when copied from the default back buffer.

It is intentionally opt-in, because not every integrated GPU is affected and the default rendering path should remain unchanged for systems where it already works correctly. While this was tested on one Intel Ivy Bridge and Mesa configuration, the same compatibility path may provide a practical workaround for other systems affected by the same framebuffer-copy behaviour.



## Visual comparison

### Before: MSAA=1, RenderToFBO=0 (disabled)

CamSpy framebuffer feedback/distortion on the affected system:

https://github.com/user-attachments/assets/83064ce8-8970-4ed8-b2d0-5bec0327ee65

### After: MSAA=1, RenderToFBO=1 (enabled)

https://github.com/user-attachments/assets/90b55ab2-e551-4f5c-9c15-09364972db90



## Behaviour

`RenderToFBO` is disabled by default, so existing behaviour is unchanged:

```ini
[Video]
RenderToFBO=0
```

When enabled, it only affects rendering while framebuffer effects are enabled:

```ini
[Video]
FramebufferEffects=1
MSAA=1
RenderToFBO=1
```

In that configuration, the game uses the existing internal game framebuffer path even without multisampling. Framebuffer effects read from the internal framebuffer, and the completed frame is copied to the default framebuffer for presentation.

`FramebufferEffects=0` continues to disable framebuffer effects, regardless of the `RenderToFBO` value.

When `MSAA > 1`, the existing MSAA render and resolve flow remains unchanged. `RenderToFBO` does not alter that flow.



## Configuration

`RenderToFBO` defaults to `0` when no value is specified in `pd.ini`.

The setting is intentionally not exposed in the in-game video options menu. To enable the compatibility path, set it to `1` under `[Video]`:

```ini
[Video]
RenderToFBO=1
```

The setting is read during video initialization, so restarting the game is required after changing its value.



## Testing

Tested on two Intel integrated-GPU environments:

### Affected Linux system

* Batocera Plus Linux 5.2.16
* Intel Celeron 1037U, 1.80 GHz
* Intel HD Graphics, Ivy Bridge generation
* 8 GB RAM
* Mesa 19.1.7
* OpenGL 3.0 / GLSL 1.30
* 1280x720

This is the system where the original framebuffer-copy issue was reproduced and where `RenderToFBO=1` fixes the affected effects with `MSAA=1`.

### Windows regression test

* Windows 11, 64-bit
* 12th Gen Intel Core i5-1235U, 1.30 GHz
* 8 GB RAM
* Intel Iris Xe Graphics, integrated GPU
* Local build compiled with MSYS2 MINGW64
* 1920x1080

On Windows 11, `FramebufferEffects=1`, `MSAA=1`, and `RenderToFBO=1` worked correctly. CamSpy, cloak/invisibility, blur, menus, and gameplay behaved as expected, with no visual or gameplay regressions observed during testing.

Test matrix completed successfully:

* `FramebufferEffects=1`, `MSAA=1`, `RenderToFBO=1`

  * CamSpy fisheye, cloak/invisibility, blur and other tested framebuffer effects worked correctly.
* `FramebufferEffects=1`, `MSAA=1`, `RenderToFBO=0`

  * Preserved the original affected framebuffer-copy path.
* `FramebufferEffects=1`, `MSAA=2`, `RenderToFBO=0`

  * Existing MSAA behaviour remained correct.
* `FramebufferEffects=1`, `MSAA=2`, `RenderToFBO=1`

  * Matched the existing MSAA path without regressions.
* `FramebufferEffects=0`, `MSAA=1`, `RenderToFBO=1`

  * The game remained functional with framebuffer effects disabled.
* Repeated restarts, gameplay, menus, fullscreen/resolution checks and extended effect use completed successfully.

A video is attached showing CamSpy working at `MSAA=1` with `RenderToFBO=1`, while the options menu shows antialiasing disabled.

No performance regression was noticeable during testing with `RenderToFBO=1` and `MSAA=1`. No formal frame-time benchmark was collected, so this is based on gameplay observation rather than measured performance data.