### PR TITLE
Prevent keyboard events from being swaollwed on certain Wayland systems

### DIFF
--- a/port/src/input.c
+++ b/port/src/input.c
@@ -756,6 +756,9 @@ s32 inputInit(void)
 
 	inputLoadBinds();
 
+	// Explicitly stop text input to prevent key events being swallowed on certain Wayland systems
+	inputStopTextInput();
+
 	return connectedMask;
 }
 


### PR DESCRIPTION
Fixes https://github.com/perfect-dark-pc-port/perfect_dark/issues/746

On certain Wayland systems (e.g. Fedora with KDE Plasma), keyboard input can get swallowed by the IME. Adding an explicit call to `SDL_StopTextInput` (via `inputStopTextInput()` ) at the end of `inputInit()` seems to prevent that, as suggested by https://github.com/libsdl-org/SDL/issues/14195#issuecomment-5273318951:

> If that's right this isn't purely a config issue: an app that has never called SDL_StartTextInput() should arguably have text input disabled from the start, and the unconditional enable is what makes the IME's behaviour reasonable from its own side.

Verified that this fixed things for me on Fedora 44. But I don't have access to any other systems with Wayland to verify further